### PR TITLE
update babel-eslint@4.0.10, use eslint-plugin-babel/arrow-parens

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,10 @@
 {
   "parser": "babel-eslint",
 
+  "plugins": [
+    "babel"
+  ],
+
   "env": {
     "es6": true,
     "node": true
@@ -34,8 +38,9 @@
   },
 
   "rules": {
+    "babel/arrow-parens": [2, "as-needed"],
+
     "array-bracket-spacing": [2, "always", {"arraysInArrays": false}],
-    "arrow-parens": [0, "as-needed"],
     "arrow-spacing": 2,
     "block-scoped-var": 0,
     "brace-style": [2, "1tbs", {"allowSingleLine": true}],

--- a/package.json
+++ b/package.json
@@ -56,11 +56,12 @@
   "devDependencies": {
     "babel": "5.8.21",
     "babel-core": "5.8.22",
-    "babel-eslint": "4.0.5",
+    "babel-eslint": "4.0.10",
     "babel-runtime": "5.8.20",
     "chai": "3.2.0",
     "coveralls": "2.11.4",
     "eslint": "1.1.0",
+    "eslint-plugin-babel": "2.1.1",
     "express": "4.13.3",
     "express3": "*",
     "flow-bin": "0.14.0",


### PR DESCRIPTION
Sorry bout that - forgot the whole point of https://github.com/babel/eslint-plugin-babel/pull/9

Ref https://github.com/graphql/express-graphql/pull/6

