### PR TITLE
Check for req.body parsed as a string

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "babel-core": "5.8.22",
     "babel-eslint": "4.0.10",
     "babel-runtime": "5.8.20",
+    "body-parser": "^1.14.0",
     "chai": "3.2.0",
     "coveralls": "2.11.4",
     "eslint": "1.1.0",

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -16,6 +16,7 @@ import { describe, it } from 'mocha';
 import { stringify } from 'querystring';
 import zlib from 'zlib';
 import multer from 'multer';
+import bodyParser from 'body-parser';
 import request from 'supertest-as-promised';
 import express4 from 'express'; // modern
 import express3 from 'express3'; // old but commonly still used
@@ -477,6 +478,31 @@ describe('test harness', () => {
           .post(urlString())
           .field('query', '{ test(who: "World") }')
           .attach('file', __filename);
+
+        expect(JSON.parse(response.text)).to.deep.equal({
+          data: {
+            test: 'Hello World'
+          }
+        });
+      });
+
+      it('allows for pre-parsed POST using application/graphql', async () => {
+        var app = express();
+
+        app.use(urlString(), bodyParser.text({ type: 'application/graphql' }));
+
+        app.use(urlString(), graphqlHTTP(req => {
+          return {
+            schema: TestSchema,
+            rootObject: { request: req }
+          };
+        }));
+
+        var req = request(app)
+          .post(urlString())
+          .set('Content-Type', 'application/graphql');
+        req.write(new Buffer('{ test(who: "World") }'));
+        var response = await req;
 
         expect(JSON.parse(response.text)).to.deep.equal({
           data: {

--- a/src/parseBody.js
+++ b/src/parseBody.js
@@ -23,6 +23,10 @@ export function parseBody(req: Request, next: NodeCallback): void {
       return next(null, req.body);
     }
 
+    if (typeof req.body === 'string') {
+      return next(null, { query: req.body });
+    }
+
     // Skip requests without content types.
     if (req.headers['content-type'] === undefined) {
       return next();

--- a/src/parseBody.js
+++ b/src/parseBody.js
@@ -18,14 +18,12 @@ import type { Request } from 'express';
 
 export function parseBody(req: Request, next: NodeCallback): void {
   try {
+
     // If express has already parsed a body, use it.
     if (typeof req.body === 'object') {
       return next(null, req.body);
     }
 
-    if (typeof req.body === 'string') {
-      return next(null, { query: req.body });
-    }
 
     // Skip requests without content types.
     if (req.headers['content-type'] === undefined) {
@@ -33,6 +31,12 @@ export function parseBody(req: Request, next: NodeCallback): void {
     }
 
     var typeInfo = contentType.parse(req);
+
+    if (typeof req.body === 'string') {
+      return typeInfo.type === 'application/graphql'
+             ? next(null, { query: req.body })
+             : next();
+    }
 
     // Use the correct body parser based on Content-Type header.
     switch (typeInfo.type) {


### PR DESCRIPTION
`req.body` may be a string if parsed with something like `body-parser`. If it is, this creates the proper object shape used by `getGraphQLParams`

Fixes https://github.com/graphql/express-graphql/issues/10