### PR TITLE
[RFC] GraphiQL when loaded in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ var graphqlHTTP = require('express-graphql');
 
 var app = express();
 
-app.use('/graphql', graphqlHTTP({ schema: MyGraphQLSchema }));
+app.use('/graphql', graphqlHTTP({ schema: MyGraphQLSchema, graphiql: true }));
 ```
 
 
@@ -32,6 +32,9 @@ The `graphqlHTTP` function accepts the following options:
     function from [`graphql-js`][].
 
   * **`pretty`**: If `true`, any JSON response will be pretty-printed.
+
+  * **`graphiql`**: If `true`, may present [GraphiQL][] when loaded directly
+    from a browser (a useful tool for debugging and exploration).
 
 
 ### HTTP Usage
@@ -48,6 +51,10 @@ the parameters:
     operations, this specifies which operation should be executed. If not
     provided, a 400 error will be returned if the `query` contains multiple
     named operations.
+
+  * **`raw`**: If the `graphiql` option is enabled and the `raw` parameter is
+    provided raw JSON will always be returned instead of GraphiQL even when
+    loaded from a browser.
 
 GraphQL will first look for each parameter in the URL's query-string:
 
@@ -95,10 +102,12 @@ app.use(session({ secret: 'keyboard cat', cookie: { maxAge: 60000 }}));
 
 app.use('/graphql', graphqlHTTP(request => ({
   schema: MySessionAwareGraphQLSchema,
-  rootValue: request.session
+  rootValue: request.session,
+  graphiql: true
 })));
 ```
 
 [`graphql-js`]: https://github.com/graphql/graphql-js
+[GraphiQL]: https://github.com/graphql/graphiql
 [`multer`]: https://github.com/expressjs/multer
 [`express-session`]: https://github.com/expressjs/session

--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -1,0 +1,124 @@
+/* @flow */
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+type GraphiQLData = { query: ?string, variables: ?Object, result: Object };
+
+// Current latest version of GraphiQL.
+var GRAPHIQL_VERSION = '0.2.4';
+
+/**
+ * When express-graphql receives a request which does not Accept JSON, but does
+ * Accept HTML, it may present GraphiQL, the in-browser GraphQL explorer IDE.
+ *
+ * When shown, it will be pre-populated with the result of having executed the
+ * requested query.
+ */
+export function renderGraphiQL(data?: GraphiQLData): string {
+  var queryString = data ? data.query : null;
+  var variablesString =
+    data && data.variables ? JSON.stringify(data.variables, null, 2) : null;
+  var resultString =
+    data && data.result ? JSON.stringify(data.result, null, 2) : null;
+
+  /* eslint-disable max-len */
+  return `<!--
+The request to this GraphQL server provided the header "Accept: text/html"
+and as a result has been presented GraphiQL - an in-browser IDE for
+exploring GraphQL.
+
+If you wish to receive JSON, provide the header "Accept: application/json" or
+add "&raw" to the end of the URL within a browser.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+  <link href="//cdn.jsdelivr.net/graphiql/${GRAPHIQL_VERSION}/graphiql.css" rel="stylesheet" />
+  <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
+  <script src="//cdn.jsdelivr.net/react/0.13.3/react.min.js"></script>
+  <script src="//cdn.jsdelivr.net/graphiql/${GRAPHIQL_VERSION}/graphiql.min.js"></script>
+</head>
+<body>
+  <script>
+    // Collect the URL parameters
+    var parameters = {};
+    window.location.search.substr(1).split('&').forEach(function (entry) {
+      var eq = entry.indexOf('=');
+      if (eq >= 0) {
+        parameters[decodeURIComponent(entry.slice(0, eq))] =
+          decodeURIComponent(entry.slice(eq + 1));
+      }
+    });
+
+    // Produce a Location query string from a parameter object.
+    function locationQuery(params) {
+      return '?' + Object.keys(params).map(function (key) {
+        return encodeURIComponent(key) + '=' +
+          encodeURIComponent(params[key]);
+      }).join('&');
+    }
+
+    // Derive a fetch URL from the current URL, sans the GraphQL parameters.
+    var graphqlParamNames = {
+      query: true,
+      variables: true,
+      operationName: true
+    };
+
+    var otherParams = {};
+    for (var k in parameters) {
+      if (parameters.hasOwnProperty(k) && graphqlParamNames[k] !== true) {
+        otherParams[k] = parameters[k];
+      }
+    }
+    var fetchURL = locationQuery(otherParams);
+
+    // Defines a GraphQL fetcher using the fetch API.
+    function graphQLFetcher(graphQLParams) {
+      return fetch(fetchURL, {
+        method: 'post',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(graphQLParams),
+      }).then(function (response) {
+        return response.json()
+      });
+    }
+
+    // When the query and variables string is edited, update the URL bar so
+    // that it can be easily shared.
+    function onEditQuery(newQuery) {
+      parameters.query = newQuery;
+      updateURL();
+    }
+
+    function onEditVariables(newVariables) {
+      parameters.variables = newVariables;
+      updateURL();
+    }
+
+    function updateURL() {
+      history.replaceState(null, null, locationQuery(parameters));
+    }
+
+    // Render <GraphiQL /> into the body.
+    React.render(
+      React.createElement(GraphiQL, {
+        fetcher: graphQLFetcher,
+        onEditQuery: onEditQuery,
+        onEditVariables: onEditVariables,
+        query: ${JSON.stringify(queryString)},
+        response: ${JSON.stringify(resultString)},
+        variables: ${JSON.stringify(variablesString)}
+      }),
+      document.body
+    );
+  </script>
+</body>
+</html>`;
+}


### PR DESCRIPTION
This RFC adds an opt-in behavior of express-graphql to render a fully functional GraphiQL instance when loaded from a browser - determed as anything that prefers HTML over JSON from the Accept header.

GraphiQL mode is enabled by providing `graphiql: true` in the options bag. It defaults to `false` which is a reasonable default, but also ensures any existing use updating to this version will not unknowingly add this feature. The examples in the README have been changed to enable GraphiQL, ideally all future users will leave this on, cargo-cult from README is likely.

When GraphiQL is shown, the query result is run on the server first and presented immediately in the GraphiQL UI.

If you wish to use the browser as a cheap cURL, just add `&raw` to the end of the URL and GraphiQL is replaced by raw JSON output.

One small detail: any non-GraphQL GET params provided will be carried through by GraphiQL when executing queries. Ideally this covers the majority of authentication cases which are likely to look something like `https://mysite/graphql?oauth=abc123&query={yo}`.