### PR TITLE
allow session cookies on same origin

### DIFF
--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -85,6 +85,7 @@ add "&raw" to the end of the URL within a browser.
         method: 'post',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(graphQLParams),
+        credentials: 'same-origin',
       }).then(function (response) {
         return response.json()
       });


### PR DESCRIPTION
I was trying to pass session information as a root value.  Without this change it doesn't work through graphiql.