### PR TITLE
[GraphiQL] Allow to pass cookies from the client 

### DIFF
--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -84,6 +84,7 @@ add "&raw" to the end of the URL within a browser.
       return fetch(fetchURL, {
         method: 'post',
         headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
         body: JSON.stringify(graphQLParams),
       }).then(function (response) {
         return response.json()


### PR DESCRIPTION
This allows to back a auth middleware in-front of the GraphiQL UI.

**Some background info:**

I wanted to deploy this GraphiQL dashboard to a production app. But, I can't deploy it without even a simple auth system. 

So, I implemented a simple basic-auth middleware and add a cookie (with some auth-key) for other requests. (specially from the `fetch`). But, by default fetch does not forward cookies. We need to add an option to do it.

Here I've only enabled `same-origin` policy. So, it's cause no harm.

