### PR TITLE
Update GraphiQL cdn version

### DIFF
--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -11,7 +11,7 @@
 type GraphiQLData = { query: ?string, variables: ?Object, result?: Object };
 
 // Current latest version of GraphiQL.
-var GRAPHIQL_VERSION = '0.2.4';
+var GRAPHIQL_VERSION = '0.3.1';
 
 /**
  * When express-graphql receives a request which does not Accept JSON, but does


### PR DESCRIPTION
Was fiddling around in chrome dev tools while using the GUI and noticed that the cdn version was not the latest. So this PR will bring it up to date.