### PR TITLE
show user-friendly errors in graphiql if request fails to server for any reason

### DIFF
--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -90,8 +90,24 @@ add "&raw" to the end of the URL within a browser.
         },
         body: JSON.stringify(graphQLParams),
         credentials: 'include',
+      }).then(function checkStatus(response) {
+        if (response.status >= 200 && response.status < 300) {
+          return response;
+        } else {
+          var error = new Error(response.status + ' (' + response.statusText + ')');
+          error.response = response;
+          throw error;
+        }
       }).then(function (response) {
         return response.json();
+      }).catch(function (err) {
+        return {
+          "errors": [
+            {
+              "message": err.message
+            }
+          ]
+        }
       });
     }
 


### PR DESCRIPTION
I was seeing very unfriendly errors in graphiql if there were issues connecting to the underlying server for any reason, e.g.  we front all our apps with nginx and if the request took too long the user would see this:

<img width="602" alt="screen shot 2016-01-29 at 2 13 43 pm" src="https://cloud.githubusercontent.com/assets/232356/12687768/88026872-c697-11e5-8c16-f32728dc889d.png">

First, I updated the `fetch` chain in `renderGraphiQL.js` to [check status codes per the fetch.js best practices](https://github.com/github/fetch#handling-http-error-statuses) before trying to parse the response json. Second, I catch all errors and return a graphql friendly error message. Now my users will see this:

<img width="861" alt="screen shot 2016-01-29 at 2 43 28 pm" src="https://cloud.githubusercontent.com/assets/232356/12687839/ef7fef24-c697-11e5-8fb4-12d5339fe019.png">
