### PR TITLE
Add Promise fallback for node.js v0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "preversion": "npm test"
   },
   "dependencies": {
+    "bluebird": "^3.3.4",
     "content-type": "~1.0.1",
     "http-errors": "~1.3.1",
     "raw-body": "~2.1.2"

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import {
   getOperationAST
 } from 'graphql';
 import httpError from 'http-errors';
+import Promise from 'bluebird';
 
 import { parseBody } from './parseBody';
 import { renderGraphiQL } from './renderGraphiQL';


### PR DESCRIPTION
I understand that Node.js v0.10.* is on the way out, but this fallback would be nice since it will only use bluebird if the current runtime does not support Promises.

Personally I work in a few environments where v0.10 is the only option at present so this would be great.