### PR TITLE
Custom validation rules

### DIFF
--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -24,7 +24,9 @@ import {
   GraphQLSchema,
   GraphQLObjectType,
   GraphQLNonNull,
-  GraphQLString
+  GraphQLString,
+  GraphQLError,
+  BREAK
 } from 'graphql';
 import graphqlHTTP from '../';
 
@@ -1263,6 +1265,46 @@ describe('test harness', () => {
         expect(response.text).to.equal(
           '{"data":{"test":"Hello World"}}'
         );
+      });
+    });
+
+    describe('Custom validation rules', () => {
+      var AlwaysInvalidRule = function(context: ValidationContext): any {
+        return {
+          enter(node) {
+            context.reportError(new GraphQLError(
+              'AlwaysInvalidRule was really invalid!'
+            ));
+            return BREAK;
+          }
+        };
+      };
+
+      it('Do not execute a query if it do not pass the custom validation.', async() => {
+        var app = express();
+
+        app.use(urlString(), graphqlHTTP({
+          schema: TestSchema,
+          validationRules: [AlwaysInvalidRule],
+          pretty: true,
+        }));
+
+        var error = await catchError(
+          request(app)
+            .get(urlString({
+              query: '{thrower}',
+            }))
+        );
+
+        expect(error.response.status).to.equal(400);
+        expect(JSON.parse(error.response.text)).to.deep.equal({
+          errors: [
+            {
+              message: 'AlwaysInvalidRule was really invalid!'
+            },
+          ]
+        });
+
       });
     });
   });

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -1269,9 +1269,9 @@ describe('test harness', () => {
     });
 
     describe('Custom validation rules', () => {
-      var AlwaysInvalidRule = function(context) {
+      var AlwaysInvalidRule = function (context) {
         return {
-          enter(node) {
+          enter() {
             context.reportError(new GraphQLError(
               'AlwaysInvalidRule was really invalid!'
             ));
@@ -1285,7 +1285,7 @@ describe('test harness', () => {
 
         app.use(urlString(), graphqlHTTP({
           schema: TestSchema,
-          validationRules: [AlwaysInvalidRule],
+          validationRules: [ AlwaysInvalidRule ],
           pretty: true,
         }));
 

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -1269,7 +1269,7 @@ describe('test harness', () => {
     });
 
     describe('Custom validation rules', () => {
-      var AlwaysInvalidRule = function(context: ValidationContext): any {
+      var AlwaysInvalidRule = function(context) {
         return {
           enter(node) {
             context.reportError(new GraphQLError(

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ import {
   execute,
   formatError,
   getOperationAST,
-  specifiedRules,
+  specifiedRules
 } from 'graphql';
 import httpError from 'http-errors';
 
@@ -54,7 +54,7 @@ export type OptionsObj = {
   formatError?: ?Function,
 
   /**
-   * An optional array of validation rules that will be validated on the document
+   * An optional array of validation rules that will be applied on the document
    * in aditional to the rules in the GraphQL spec
    */
    validationRules?: ?Array<any>,

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,8 @@ import {
   validate,
   execute,
   formatError,
-  getOperationAST
+  getOperationAST,
+  specifiedRules,
 } from 'graphql';
 import httpError from 'http-errors';
 
@@ -53,6 +54,12 @@ export type OptionsObj = {
   formatError?: ?Function,
 
   /**
+   * An optional array of validation rules that will be validated on the document
+   * in aditional to the rules in the GraphQL spec
+   */
+   validationRules?: ?Array<any>,
+
+  /**
    * A boolean to optionally enable GraphiQL mode.
    */
   graphiql?: ?boolean,
@@ -81,6 +88,7 @@ export default function graphqlHTTP(options: Options): Middleware {
     let query;
     let variables;
     let operationName;
+    let validationRules;
 
     // Use promises as a mechanism for capturing any thrown errors during the
     // asyncronous process.
@@ -93,6 +101,11 @@ export default function graphqlHTTP(options: Options): Middleware {
       pretty = optionsObj.pretty;
       graphiql = optionsObj.graphiql;
       formatErrorFn = optionsObj.formatError;
+
+      validationRules = specifiedRules;
+      if (optionsObj.validationRules) {
+        validationRules = validationRules.concat(optionsObj.validationRules);
+      }
 
       // GraphQL HTTP only supports GET and POST methods.
       if (request.method !== 'GET' && request.method !== 'POST') {
@@ -136,7 +149,7 @@ export default function graphqlHTTP(options: Options): Middleware {
       }
 
       // Validate AST, reporting any errors.
-      const validationErrors = validate(schema, documentAST);
+      const validationErrors = validate(schema, documentAST, validationRules);
       if (validationErrors.length > 0) {
         // Return 400: Bad Request if any validation errors exist.
         response.status(400);


### PR DESCRIPTION
The most useful use case I could think of right now which also is the reason I proposed this is to set limit on query complexity. This would be a great starting point as we can take the advantage of the awesome [graphql's visitor api](https://github.com/graphql/graphql-js/blob/d5ecfe08b1f74dedd3e42186426100eddc07da7a/src/language/visitor.jsl).