### PR TITLE
Escape query, variables and response on initial page load 

### DIFF
--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -1130,6 +1130,24 @@ describe('test harness', () => {
         );
       });
 
+      it('escapes HTML in queries within GraphiQL', async () => {
+        var app = express();
+
+        app.use(urlString(), graphqlHTTP({
+          schema: TestSchema,
+          graphiql: true
+        }));
+
+        var error = await catchError(
+          request(app).get(urlString({ query: '</script><script>alert(1)</script>' }))
+                      .set('Accept', 'text/html')
+        );
+
+        expect(error.response.status).to.equal(400);
+        expect(error.response.type).to.equal('text/html');
+        expect(error.response.text).to.not.include('</script><script>alert(1)</script>');
+      });
+
       it('GraphiQL renders provided variables', async () => {
         var app = express();
 

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -1148,6 +1148,26 @@ describe('test harness', () => {
         expect(error.response.text).to.not.include('</script><script>alert(1)</script>');
       });
 
+      it('escapes HTML in variables within GraphiQL', async () => {
+        var app = express();
+
+        app.use(urlString(), graphqlHTTP({
+          schema: TestSchema,
+          graphiql: true
+        }));
+
+        var response = await request(app).get(urlString({
+          query: 'query helloWho($who: String) { test(who: $who) }',
+          variables: JSON.stringify({
+            who: '</script><script>alert(1)</script>'
+          })
+        })) .set('Accept', 'text/html');
+
+        expect(response.status).to.equal(200);
+        expect(response.type).to.equal('text/html');
+        expect(response.text).to.not.include('</script><script>alert(1)</script>');
+      });
+
       it('GraphiQL renders provided variables', async () => {
         var app = express();
 

--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -13,6 +13,27 @@ type GraphiQLData = { query: ?string, variables: ?Object, result?: Object };
 // Current latest version of GraphiQL.
 const GRAPHIQL_VERSION = '0.6.0';
 
+const UNSAFE_REGEXP = /[<>\/\u2028\u2029]/g;
+const UNSAFE_ALTERNATIVES = {
+  '<': '\\u003C',
+  '>': '\\u003E',
+  '/': '\\u002F',
+  '\u2028': '\\u2028',
+  '\u2029': '\\u2029',
+};
+
+function safeSerialize(data) {
+  let str = JSON.stringify(data);
+
+  if (typeof str === 'string') {
+    str = JSON.stringify(data).replace(
+      UNSAFE_REGEXP, char => UNSAFE_ALTERNATIVES[char]
+    );
+  }
+
+  return str;
+}
+
 /**
  * When express-graphql receives a request which does not Accept JSON, but does
  * Accept HTML, it may present GraphiQL, the in-browser GraphQL explorer IDE.
@@ -131,8 +152,8 @@ add "&raw" to the end of the URL within a browser.
         fetcher: graphQLFetcher,
         onEditQuery: onEditQuery,
         onEditVariables: onEditVariables,
-        query: ${JSON.stringify(queryString)},
-        response: ${JSON.stringify(resultString)},
+        query: ${safeSerialize(queryString)},
+        response: ${safeSerialize(resultString)},
         variables: ${JSON.stringify(variablesString)}
       }),
       document.body

--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -154,7 +154,7 @@ add "&raw" to the end of the URL within a browser.
         onEditVariables: onEditVariables,
         query: ${safeSerialize(queryString)},
         response: ${safeSerialize(resultString)},
-        variables: ${JSON.stringify(variablesString)}
+        variables: ${safeSerialize(variablesString)}
       }),
       document.body
     );


### PR DESCRIPTION
HTML was was not properly escaped in queries or variables causing GraphiQL to break. See #47 