### PR TITLE
Add context argument to express-graphql to make it work with 0.5.0-beta.1 release of graphql-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,8 @@
   "dependencies": {
     "content-type": "~1.0.1",
     "http-errors": "~1.3.1",
-    "raw-body": "~2.1.2"
-  },
-  "peerDependencies": {
-    "graphql": "^0.4.16"
+    "raw-body": "~2.1.2",
+    "graphql": "https://github.com/apollostack/graphql-js.git#npm-dist"
   },
   "devDependencies": {
     "babel": "5.8.21",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
   "dependencies": {
     "content-type": "~1.0.1",
     "http-errors": "~1.3.1",
-    "raw-body": "~2.1.2",
-    "graphql": "https://github.com/apollostack/graphql-js.git#npm-dist"
+    "raw-body": "~2.1.2"
   },
   "devDependencies": {
     "babel": "5.8.21",
@@ -71,5 +70,8 @@
     "sane": "1.1.3",
     "supertest": "1.0.1",
     "supertest-as-promised": "2.0.2"
+  },
+  "peerDependencies": {
+    "graphql": "^0.5.0-beta.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "express": "4.13.3",
     "express3": "*",
     "flow-bin": "0.21.0",
-    "graphql": "0.4.16",
+    "graphql": "^0.5.0-beta.1",
     "isparta": "3.0.3",
     "mocha": "2.2.5",
     "multer": "1.0.3",

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -45,6 +45,10 @@ var QueryRootType = new GraphQLObjectType({
     thrower: {
       type: new GraphQLNonNull(GraphQLString),
       resolve: () => { throw new Error('Throws!'); }
+    },
+    context: {
+      type: GraphQLString,
+      resolve: (obj, args, context) => context,
     }
   }
 });
@@ -307,6 +311,30 @@ describe('test harness', () => {
         expect(JSON.parse(response.text)).to.deep.equal({
           data: {
             test: 'Hello World'
+          }
+        });
+      });
+
+      it('Allows passing in a context', async () => {
+        var app = express();
+
+        app.use(urlString(), graphqlHTTP({
+          schema: TestSchema,
+          context: 'testValue'
+        }));
+
+        var response = await request(app)
+          .get(urlString({
+            operationName: 'TestQuery',
+            query: `
+              query TestQuery { context }
+            `
+          }));
+
+        expect(response.status).to.equal(200);
+        expect(JSON.parse(response.text)).to.deep.equal({
+          data: {
+            context: 'testValue'
           }
         });
       });

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,11 @@ export type OptionsObj = {
   schema: Object,
 
   /**
+   * A value to pass as the context to the graphql() function.
+   */
+  context?: ?mixed,
+
+  /**
    * An object to pass as the rootValue to the graphql() function.
    */
   rootValue?: ?Object,
@@ -80,6 +85,7 @@ export default function graphqlHTTP(options: Options): Middleware {
     // Higher scoped variables are referred to at various stages in the
     // asyncronous state machine below.
     let schema;
+    let context;
     let rootValue;
     let pretty;
     let graphiql;
@@ -97,6 +103,7 @@ export default function graphqlHTTP(options: Options): Middleware {
       // Get GraphQL options given this request.
       const optionsObj = getOptions(options, request);
       schema = optionsObj.schema;
+      context = optionsObj.context;
       rootValue = optionsObj.rootValue;
       pretty = optionsObj.pretty;
       graphiql = optionsObj.graphiql;
@@ -183,7 +190,7 @@ export default function graphqlHTTP(options: Options): Middleware {
           schema,
           documentAST,
           rootValue,
-          {},
+          context,
           variables,
           operationName
         );

--- a/src/index.js
+++ b/src/index.js
@@ -177,13 +177,13 @@ export default function graphqlHTTP(options: Options): Middleware {
           );
         }
       }
-
       // Perform the execution, reporting any errors creating the context.
       try {
         return execute(
           schema,
           documentAST,
           rootValue,
+          {},
           variables,
           operationName
         );


### PR DESCRIPTION
This adds the context as an argument, making sure that express-graphql works with graphql-js v0.5.0-beta.1