### PR TITLE
Fix react rendering

### DIFF
--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -142,7 +142,7 @@ add "&raw" to the end of the URL within a browser.
     }
 
     // Render <GraphiQL /> into the body.
-    React.render(
+    ReactDOM.render(
       React.createElement(GraphiQL, {
         fetcher: graphQLFetcher,
         onEditQuery: onEditQuery,


### PR DESCRIPTION
GraphiQL currently doesn't render because `React.render` is undefined. It should probably be `ReactDOM.render`.