### PR TITLE
Clarify error message for option function with promise

### DIFF
--- a/src/__tests__/usage-test.js
+++ b/src/__tests__/usage-test.js
@@ -43,7 +43,7 @@ describe('Useful errors when incorrectly used', () => {
     expect(JSON.parse(caughtError.response.text)).to.deep.equal({
       errors: [
         { message:
-          'GraphQL middleware option function must return an options object.' }
+          'GraphQL middleware option function must return an options object or a promise which will be resolved to an options object.' }
       ]
     });
   });
@@ -64,7 +64,7 @@ describe('Useful errors when incorrectly used', () => {
     expect(JSON.parse(caughtError.response.text)).to.deep.equal({
       errors: [
         { message:
-          'GraphQL middleware option function must return an options object.' }
+          'GraphQL middleware option function must return an options object or a promise which will be resolved to an options object.' }
       ]
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,8 @@ export default function graphqlHTTP(options: Options): Middleware {
       // Assert that optionsData is in fact an Object.
       if (!optionsData || typeof optionsData !== 'object') {
         throw new Error(
-          'GraphQL middleware option function must return an options object.'
+          'GraphQL middleware option function must return an options object ' +
+          'or a promise which will be resolved to an options object.'
         );
       }
 


### PR DESCRIPTION
It should be more clear if we can tell user that function can return either an object or an promise.