### PR TITLE
Allow passing "limit" option into express-graphql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@
 .idea
 npm-debug.log
 
-dist
 node_modules
 coverage

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,253 @@
+
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/**
+ * Used to configure the graphQLHTTP middleware by providing a schema
+ * and other configuration options.
+ *
+ * Options can be provided as an Object, a Promise for an Object, or a Function
+ * that returns an Object or a Promise for an Object.
+ */
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports['default'] = graphqlHTTP;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _graphql = require('graphql');
+
+var _httpErrors = require('http-errors');
+
+var _httpErrors2 = _interopRequireDefault(_httpErrors);
+
+var _parseBody = require('./parseBody');
+
+var _renderGraphiQL = require('./renderGraphiQL');
+
+/**
+ * Middleware for express; takes an options object or function as input to
+ * configure behavior, and returns an express middleware.
+ */
+
+function graphqlHTTP(options) {
+  if (!options) {
+    throw new Error('GraphQL middleware requires options.');
+  }
+
+  return function (request, response) {
+    // Higher scoped variables are referred to at various stages in the
+    // asyncronous state machine below.
+    var schema = undefined;
+    var context = undefined;
+    var rootValue = undefined;
+    var pretty = undefined;
+    var graphiql = undefined;
+    var formatErrorFn = undefined;
+    var showGraphiQL = undefined;
+    var query = undefined;
+    var variables = undefined;
+    var operationName = undefined;
+    var validationRules = undefined;
+
+    // Promises are used as a mechanism for capturing any thrown errors during
+    // the asyncronous process below.
+
+    // Resolve the Options to get OptionsData.
+    new Promise(function (resolve) {
+      resolve(typeof options === 'function' ? options(request) : options);
+    }).then(function (optionsData) {
+      // Assert that optionsData is in fact an Object.
+      if (!optionsData || typeof optionsData !== 'object') {
+        throw new Error('GraphQL middleware option function must return an options object ' + 'or a promise which will be resolved to an options object.');
+      }
+
+      // Assert that schema is required.
+      if (!optionsData.schema) {
+        throw new Error('GraphQL middleware options must contain a schema.');
+      }
+
+      // Collect information from the options data object.
+      schema = optionsData.schema;
+      context = optionsData.context;
+      rootValue = optionsData.rootValue;
+      pretty = optionsData.pretty;
+      graphiql = optionsData.graphiql;
+      formatErrorFn = optionsData.formatError;
+
+      validationRules = _graphql.specifiedRules;
+      if (optionsData.validationRules) {
+        validationRules = validationRules.concat(optionsData.validationRules);
+      }
+
+      // GraphQL HTTP only supports GET and POST methods.
+      if (request.method !== 'GET' && request.method !== 'POST') {
+        response.set('Allow', 'GET, POST');
+        throw (0, _httpErrors2['default'])(405, 'GraphQL only supports GET and POST requests.');
+      }
+
+      // Parse the Request body.
+      return (0, _parseBody.parseBody)(request, options.limit);
+    }).then(function (data) {
+      showGraphiQL = graphiql && canDisplayGraphiQL(request, data);
+
+      // Get GraphQL params from the request and POST body data.
+      var params = getGraphQLParams(request, data);
+      query = params.query;
+      variables = params.variables;
+      operationName = params.operationName;
+
+      // If there is no query, but GraphiQL will be displayed, do not produce
+      // a result, otherwise return a 400: Bad Request.
+      if (!query) {
+        if (showGraphiQL) {
+          return null;
+        }
+        throw (0, _httpErrors2['default'])(400, 'Must provide query string.');
+      }
+
+      // GraphQL source.
+      var source = new _graphql.Source(query, 'GraphQL request');
+
+      // Parse source to AST, reporting any syntax error.
+      var documentAST = undefined;
+      try {
+        documentAST = (0, _graphql.parse)(source);
+      } catch (syntaxError) {
+        // Return 400: Bad Request if any syntax errors errors exist.
+        response.status(400);
+        return { errors: [syntaxError] };
+      }
+
+      // Validate AST, reporting any errors.
+      var validationErrors = (0, _graphql.validate)(schema, documentAST, validationRules);
+      if (validationErrors.length > 0) {
+        // Return 400: Bad Request if any validation errors exist.
+        response.status(400);
+        return { errors: validationErrors };
+      }
+
+      // Only query operations are allowed on GET requests.
+      if (request.method === 'GET') {
+        // Determine if this GET request will perform a non-query.
+        var operationAST = (0, _graphql.getOperationAST)(documentAST, operationName);
+        if (operationAST && operationAST.operation !== 'query') {
+          // If GraphiQL can be shown, do not perform this query, but
+          // provide it to GraphiQL so that the requester may perform it
+          // themselves if desired.
+          if (showGraphiQL) {
+            return null;
+          }
+
+          // Otherwise, report a 405: Method Not Allowed error.
+          response.set('Allow', 'POST');
+          throw (0, _httpErrors2['default'])(405, 'Can only perform a ' + operationAST.operation + ' operation ' + 'from a POST request.');
+        }
+      }
+      // Perform the execution, reporting any errors creating the context.
+      try {
+        return (0, _graphql.execute)(schema, documentAST, rootValue, context, variables, operationName);
+      } catch (contextError) {
+        // Return 400: Bad Request if any execution context errors exist.
+        response.status(400);
+        return { errors: [contextError] };
+      }
+    })['catch'](function (error) {
+      // If an error was caught, report the httpError status, or 500.
+      response.status(error.status || 500);
+      return { errors: [error] };
+    }).then(function (result) {
+      // Format any encountered errors.
+      if (result && result.errors) {
+        result.errors = result.errors.map(formatErrorFn || _graphql.formatError);
+      }
+
+      // If allowed to show GraphiQL, present it instead of JSON.
+      if (showGraphiQL) {
+        response.set('Content-Type', 'text/html').send((0, _renderGraphiQL.renderGraphiQL)({ query: query, variables: variables, operationName: operationName, result: result }));
+      } else {
+        // Otherwise, present JSON directly.
+        response.set('Content-Type', 'application/json').send(JSON.stringify(result, null, pretty ? 2 : 0));
+      }
+    });
+  };
+}
+
+/**
+ * Helper function to get the GraphQL params from the request.
+ */
+function getGraphQLParams(request, data) {
+  // GraphQL Query string.
+  var query = request.query.query || data.query;
+
+  // Parse the variables if needed.
+  var variables = request.query.variables || data.variables;
+  if (variables && typeof variables === 'string') {
+    try {
+      variables = JSON.parse(variables);
+    } catch (error) {
+      throw (0, _httpErrors2['default'])(400, 'Variables are invalid JSON.');
+    }
+  }
+
+  // Name of GraphQL operation to execute.
+  var operationName = request.query.operationName || data.operationName;
+
+  return { query: query, variables: variables, operationName: operationName };
+}
+
+/**
+ * Helper function to determine if GraphiQL can be displayed.
+ */
+function canDisplayGraphiQL(request, data) {
+  // If `raw` exists, GraphiQL mode is not enabled.
+  var raw = request.query.raw !== undefined || data.raw !== undefined;
+  // Allowed to show GraphiQL if not requested as raw and this request
+  // prefers HTML over JSON.
+  return !raw && request.accepts(['json', 'html']) === 'html';
+}
+module.exports = exports['default'];
+
+/**
+ * A GraphQL schema from graphql-js.
+ */
+
+/**
+ * A value to pass as the context to the graphql() function.
+ */
+
+/**
+ * An object to pass as the rootValue to the graphql() function.
+ */
+
+/**
+ * A boolean to configure whether the output should be pretty-printed.
+ */
+
+/**
+ * An optional function which will be used to format any errors produced by
+ * fulfilling a GraphQL operation. If no function is provided, GraphQL's
+ * default spec-compliant `formatError` function will be used.
+ */
+
+/**
+ * An optional array of validation rules that will be applied on the document
+ * in additional to those defined by the GraphQL spec.
+ */
+
+/**
+ * A boolean to optionally enable GraphiQL mode.
+ */
+
+/**
+ * An option to set the max file size
+ */

--- a/dist/parseBody.js
+++ b/dist/parseBody.js
@@ -1,0 +1,152 @@
+
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.parseBody = parseBody;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _contentType = require('content-type');
+
+var _contentType2 = _interopRequireDefault(_contentType);
+
+var _rawBody = require('raw-body');
+
+var _rawBody2 = _interopRequireDefault(_rawBody);
+
+var _httpErrors = require('http-errors');
+
+var _httpErrors2 = _interopRequireDefault(_httpErrors);
+
+var _querystring = require('querystring');
+
+var _querystring2 = _interopRequireDefault(_querystring);
+
+var _zlib = require('zlib');
+
+var _zlib2 = _interopRequireDefault(_zlib);
+
+function parseBody(req, limit) {
+  return new Promise(function (resolve, reject) {
+    // If express has already parsed a body as a keyed object, use it.
+    if (typeof req.body === 'object' && !(req.body instanceof Buffer)) {
+      return resolve(req.body);
+    }
+
+    // Skip requests without content types.
+    if (req.headers['content-type'] === undefined) {
+      return resolve({});
+    }
+
+    var typeInfo = _contentType2['default'].parse(req);
+
+    // If express has already parsed a body as a string, and the content-type
+    // was application/graphql, parse the string body.
+    if (typeof req.body === 'string' && typeInfo.type === 'application/graphql') {
+      return resolve(graphqlParser(req.body));
+    }
+
+    // Already parsed body we didn't recognise? Parse nothing.
+    if (req.body) {
+      return resolve({});
+    }
+
+    // Use the correct body parser based on Content-Type header.
+    switch (typeInfo.type) {
+      case 'application/graphql':
+        return read(req, typeInfo, graphqlParser, resolve, reject, limit);
+      case 'application/json':
+        return read(req, typeInfo, jsonEncodedParser, resolve, reject, limit);
+      case 'application/x-www-form-urlencoded':
+        return read(req, typeInfo, urlEncodedParser, resolve, reject, limit);
+    }
+
+    // If no Content-Type header matches, parse nothing.
+    return resolve({});
+  });
+}
+
+function jsonEncodedParser(body) {
+  if (jsonObjRegex.test(body)) {
+    /* eslint-disable no-empty */
+    try {
+      return JSON.parse(body);
+    } catch (error) {}
+    // Do nothing
+
+    /* eslint-enable no-empty */
+  }
+  throw (0, _httpErrors2['default'])(400, 'POST body sent invalid JSON.');
+}
+
+function urlEncodedParser(body) {
+  return _querystring2['default'].parse(body);
+}
+
+function graphqlParser(body) {
+  return { query: body };
+}
+
+/**
+ * RegExp to match an Object-opening brace "{" as the first non-space
+ * in a string. Allowed whitespace is defined in RFC 7159:
+ *
+ *     x20  Space
+ *     x09  Horizontal tab
+ *     x0A  Line feed or New line
+ *     x0D  Carriage return
+ */
+var jsonObjRegex = /^[\x20\x09\x0a\x0d]*\{/;
+
+// Read and parse a request body.
+function read(req, typeInfo, parseFn, resolve, reject, limit) {
+  var charset = (typeInfo.parameters.charset || 'utf-8').toLowerCase();
+
+  // Assert charset encoding per JSON RFC 7159 sec 8.1
+  if (charset.slice(0, 4) !== 'utf-') {
+    throw (0, _httpErrors2['default'])(415, 'Unsupported charset "' + charset.toUpperCase() + '".');
+  }
+
+  // Get content-encoding (e.g. gzip)
+  var encoding = (req.headers['content-encoding'] || 'identity').toLowerCase();
+  var length = encoding === 'identity' ? req.headers['content-length'] : null;
+  var stream = decompressed(req, encoding);
+
+  // Read body from stream.
+  (0, _rawBody2['default'])(stream, { encoding: charset, length: length, limit: limit }, function (err, body) {
+    if (err) {
+      return reject(err.type === 'encoding.unsupported' ? (0, _httpErrors2['default'])(415, 'Unsupported charset "' + charset.toUpperCase() + '".') : (0, _httpErrors2['default'])(400, 'Invalid body: ' + err.message + '.'));
+    }
+
+    try {
+      // Decode and parse body.
+      return resolve(parseFn(body));
+    } catch (error) {
+      return reject(error);
+    }
+  });
+}
+
+// Return a decompressed stream, given an encoding.
+function decompressed(req, encoding) {
+  switch (encoding) {
+    case 'identity':
+      return req;
+    case 'deflate':
+      return req.pipe(_zlib2['default'].createInflate());
+    case 'gzip':
+      return req.pipe(_zlib2['default'].createGunzip());
+  }
+  throw (0, _httpErrors2['default'])(415, 'Unsupported content-encoding "' + encoding + '".');
+}

--- a/dist/renderGraphiQL.js
+++ b/dist/renderGraphiQL.js
@@ -1,0 +1,42 @@
+
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.renderGraphiQL = renderGraphiQL;
+
+// Current latest version of GraphiQL.
+var GRAPHIQL_VERSION = '0.7.0';
+
+// Ensures string values are save to be used within a <script> tag.
+function safeSerialize(data) {
+  return data ? JSON.stringify(data).replace(/\//g, '\\/') : null;
+}
+
+/**
+ * When express-graphql receives a request which does not Accept JSON, but does
+ * Accept HTML, it may present GraphiQL, the in-browser GraphQL explorer IDE.
+ *
+ * When shown, it will be pre-populated with the result of having executed the
+ * requested query.
+ */
+
+function renderGraphiQL(data) {
+  var queryString = data.query;
+  var variablesString = data.variables ? JSON.stringify(data.variables, null, 2) : null;
+  var resultString = data.result ? JSON.stringify(data.result, null, 2) : null;
+  var operationName = data.operationName;
+
+  /* eslint-disable max-len */
+  return '<!--\nThe request to this GraphQL server provided the header "Accept: text/html"\nand as a result has been presented GraphiQL - an in-browser IDE for\nexploring GraphQL.\n\nIf you wish to receive JSON, provide the header "Accept: application/json" or\nadd "&raw" to the end of the URL within a browser.\n-->\n<!DOCTYPE html>\n<html>\n<head>\n  <style>\n    html, body {\n      height: 100%;\n      margin: 0;\n      overflow: hidden;\n      width: 100%;\n    }\n  </style>\n  <link href="//cdn.jsdelivr.net/graphiql/' + GRAPHIQL_VERSION + '/graphiql.css" rel="stylesheet" />\n  <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>\n  <script src="//cdn.jsdelivr.net/react/15.0.0/react.min.js"></script>\n  <script src="//cdn.jsdelivr.net/react/15.0.0/react-dom.min.js"></script>\n  <script src="//cdn.jsdelivr.net/graphiql/' + GRAPHIQL_VERSION + '/graphiql.min.js"></script>\n</head>\n<body>\n  <script>\n    // Collect the URL parameters\n    var parameters = {};\n    window.location.search.substr(1).split(\'&\').forEach(function (entry) {\n      var eq = entry.indexOf(\'=\');\n      if (eq >= 0) {\n        parameters[decodeURIComponent(entry.slice(0, eq))] =\n          decodeURIComponent(entry.slice(eq + 1));\n      }\n    });\n\n    // Produce a Location query string from a parameter object.\n    function locationQuery(params) {\n      return \'?\' + Object.keys(params).map(function (key) {\n        return encodeURIComponent(key) + \'=\' +\n          encodeURIComponent(params[key]);\n      }).join(\'&\');\n    }\n\n    // Derive a fetch URL from the current URL, sans the GraphQL parameters.\n    var graphqlParamNames = {\n      query: true,\n      variables: true,\n      operationName: true\n    };\n\n    var otherParams = {};\n    for (var k in parameters) {\n      if (parameters.hasOwnProperty(k) && graphqlParamNames[k] !== true) {\n        otherParams[k] = parameters[k];\n      }\n    }\n    var fetchURL = locationQuery(otherParams);\n\n    // Defines a GraphQL fetcher using the fetch API.\n    function graphQLFetcher(graphQLParams) {\n      return fetch(fetchURL, {\n        method: \'post\',\n        headers: {\n          \'Accept\': \'application/json\',\n          \'Content-Type\': \'application/json\'\n        },\n        body: JSON.stringify(graphQLParams),\n        credentials: \'include\',\n      }).then(function (response) {\n        return response.text();\n      }).then(function (responseBody) {\n        try {\n          return JSON.parse(responseBody);\n        } catch (error) {\n          return responseBody;\n        }\n      });\n    }\n\n    // When the query and variables string is edited, update the URL bar so\n    // that it can be easily shared.\n    function onEditQuery(newQuery) {\n      parameters.query = newQuery;\n      updateURL();\n    }\n\n    function onEditVariables(newVariables) {\n      parameters.variables = newVariables;\n      updateURL();\n    }\n\n    function onEditOperationName(newOperationName) {\n      parameters.operationName = newOperationName;\n      updateURL();\n    }\n\n    function updateURL() {\n      history.replaceState(null, null, locationQuery(parameters));\n    }\n\n    // Render <GraphiQL /> into the body.\n    ReactDOM.render(\n      React.createElement(GraphiQL, {\n        fetcher: graphQLFetcher,\n        onEditQuery: onEditQuery,\n        onEditVariables: onEditVariables,\n        onEditOperationName: onEditOperationName,\n        query: ' + safeSerialize(queryString) + ',\n        response: ' + safeSerialize(resultString) + ',\n        variables: ' + safeSerialize(variablesString) + ',\n        operationName: ' + safeSerialize(operationName) + ',\n      }),\n      document.body\n    );\n  </script>\n</body>\n</html>';
+}

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ export type OptionsData = {
    * A boolean to optionally enable GraphiQL mode.
    */
   graphiql?: ?boolean,
-  
+
   /**
    * An option to set the max file size
    */

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,11 @@ export type OptionsData = {
    * A boolean to optionally enable GraphiQL mode.
    */
   graphiql?: ?boolean,
+  
+  /**
+   * An option to set the max file size
+   */
+  limit?: ?number,
 };
 
 type Middleware = (request: Request, response: Response) => void;
@@ -142,7 +147,7 @@ export default function graphqlHTTP(options: Options): Middleware {
       }
 
       // Parse the Request body.
-      return parseBody(request);
+      return parseBody(request, options.limit);
     }).then(data => {
       showGraphiQL = graphiql && canDisplayGraphiQL(request, data);
 


### PR DESCRIPTION
I decided to do file uploading with GraphQL using base64, thus needed to raise the request body limit and implemented an option for it. Is this useful in the main branch?
