### PR TITLE
Add some meta to GraphiQL head

### DIFF
--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -51,7 +51,7 @@ add "&raw" to the end of the URL within a browser.
 <html>
 <head>
   <meta charset="utf-8" /> 
-  <title>GraphQL</title>
+  <title>GraphiQL</title>
   <meta name="robots" content="noindex" />
   <style>
     html, body {

--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -50,7 +50,7 @@ add "&raw" to the end of the URL within a browser.
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8" /> 
+  <meta charset="utf-8" />
   <title>GraphiQL</title>
   <meta name="robots" content="noindex" />
   <style>

--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -50,6 +50,9 @@ add "&raw" to the end of the URL within a browser.
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8" /> 
+  <title>GraphQL</title>
+  <meta name="robots" content="noindex" />
   <style>
     html, body {
       height: 100%;


### PR DESCRIPTION
This adds some basic metadata to improve UX including:

- A charset meta tag. This helps in case GraphQL data contains some special UTF8 characters.
- A title like: `http://localhost:3000/?query=%7B%0A%20%20personList%20%7B%0A%20%20%20%20edges…` is not a fun user experience.
- A meta tag which prevents robots from indexing a GraphiQL page. GraphiQL should probably never be exposed publicly, however accidents do happen.