### PR TITLE
Send response to thunk with request

### DIFF
--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -858,6 +858,28 @@ describe('test harness', () => {
       });
     });
 
+    it('will send request and response when using thunk', async () => {
+      const app = express();
+
+      let hasRequest = false;
+      let hasResponse = false;
+
+      app.use(urlString(), graphqlHTTP((req, res) => {
+        if (req) {
+          hasRequest = true;
+        }
+        if (res) {
+          hasResponse = true;
+        }
+        return { schema: TestSchema };
+      }));
+
+      await request(app).get(urlString({ query: '{test}' }));
+
+      expect(hasRequest).to.equal(true);
+      expect(hasResponse).to.equal(true);
+    });
+
     describe('Error handling functionality', () => {
       it('handles field errors caught by GraphQL', async () => {
         const app = express();

--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,11 @@ export default function graphqlHTTP(options: Options): Middleware {
 
     // Resolve the Options to get OptionsData.
     new Promise(resolve => {
-      resolve(typeof options === 'function' ? options(request) : options);
+      resolve(
+        typeof options === 'function' ?
+          options(request, response) :
+          options
+      );
     }).then(optionsData => {
       // Assert that optionsData is in fact an Object.
       if (!optionsData || typeof optionsData !== 'object') {


### PR DESCRIPTION
I use [`on-finished`](https://www.npmjs.com/package/on-finished) to do cleanup at the end of a GraphQL request. Having the response object is necessary for this.