### PR TITLE
Remove http-errors from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "express3": "*",
     "flow-bin": "0.25.0",
     "graphql": "0.6.0",
-    "http-errors": "1.4.0",
     "isparta": "4.0.0",
     "mocha": "2.5.3",
     "multer": "1.1.0",


### PR DESCRIPTION
http-errors is already a dependency in package.json