### PR TITLE
Return main promise

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ export default function graphqlHTTP(options: Options): Middleware {
     // the asyncronous process below.
 
     // Resolve the Options to get OptionsData.
-    new Promise(resolve => {
+    return new Promise(resolve => {
       resolve(
         typeof options === 'function' ?
           options(request, response) :

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ export type OptionsData = {
   graphiql?: ?boolean,
 };
 
-type Middleware = (request: Request, response: Response) => void;
+type Middleware = (request: Request, response: Response) => Promise<void>;
 
 /**
  * Middleware for express; takes an options object or function as input to


### PR DESCRIPTION
Returning the main promise will let us do things like time execution and perform some cleanups after the request is processed.