### PR TITLE
Add option to format result before sending to the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ The `graphqlHTTP` function accepts the following options:
     provided, GraphQL's default spec-compliant [`formatError`][] function will
     be used.
 
+  * **`formatResult`**: An optional function which will be used to format the
+    result of the GraphQL operation. Invoked with the result from graphql-js
+    and the context.
+
   * **`validationRules`**: Optional additional validation rules queries must
     satisfy in addition to those defined by the GraphQL spec.
 

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -964,6 +964,28 @@ describe('test harness', () => {
         });
       });
 
+      it('allows for custom result formatting', async () => {
+        const app = server();
+
+        app.use(urlString(), graphqlHTTP({
+          schema: TestSchema,
+          context: { foo: 'bar' },
+          formatResult(response, context) {
+            return Object.assign(response, context);
+          }
+        }));
+
+
+        const response = await request(app)
+          .get(urlString({
+            query: '{test}'
+          }));
+
+        expect(response.text).to.equal(
+          '{"data":{"test":"Hello World"},"foo":"bar"}'
+        );
+      });
+
       it('handles syntax errors caught by GraphQL', async () => {
         const app = server();
 


### PR DESCRIPTION
Adds an option to provide a function to format the result before sending to the client. My use case is to create a debug mode where I can return information about each request our GraphQL server makes to our REST API. As each request is made, the debug information is appended to the context, then returned as part of the json response.
