### PR TITLE
return undefined instead of null in safeSerialize to make localStorage functionality back

### DIFF
--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -20,7 +20,7 @@ const GRAPHIQL_VERSION = '0.7.1';
 
 // Ensures string values are save to be used within a <script> tag.
 function safeSerialize(data) {
-  return data ? JSON.stringify(data).replace(/\//g, '\\/') : null;
+  return data ? JSON.stringify(data).replace(/\//g, '\\/') : undefined;
 }
 
 /**


### PR DESCRIPTION
According to the implementation in [graphiql](https://github.com/graphql/graphiql/blob/master/src/components/GraphiQL.js#L139) , I think we should change `null` to `undefined` in order to enable the localStorage functionality in graphiql.
