### PR TITLE
[RFC] Persisted Document support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ The `graphqlHTTP` function accepts the following options:
   * **`validationRules`**: Optional additional validation rules queries must
     satisfy in addition to those defined by the GraphQL spec.
 
+  * **`loadPersistedDocument`**: A function that takes an input id and returns a
+    valid Document. If provided, this will allow your GraphQL endpoint to execute
+    a document specified via `documentID`.
+
+  * **`persistValidatedDocument`**: A function that takes a validated Document and
+    returns an id that can be used to load it later. This is used in conjunction
+    with `loadPersistedDocument`. Providing this function will enable persisting
+    documents via the `document` parameter at the `/persist` subpath. It is
+    recommended that this option only be enabled in development deployments.
 
 ## HTTP Usage
 
@@ -140,6 +149,21 @@ new GraphQLObjectType({
 });
 ```
 
+## Persisted Documents
+
+Putting control of the query in to clients hands is one of the primary benefits
+of GraphQL. Though when this is deployed to production naively, it is possible to
+end up uploading and revalidating the same document text across all clients of a
+particular deployment. It can even be problematic within a single client, sending
+the exact same query repeatedly. Uploading and validating a large GraphQL document
+can be very costly, especially over a poor network connection from a mobile device
+with something large and complex such as Facebook's News Feed GraphQL query.
+
+One solution to this problem that was developed early in the use of GraphQL at
+Facebook was persisted documents. At build time, we take the GraphQL document and
+persist it on the server getting back an ID. Then at runtime, we only upload the
+ID of the document and the variables. When the server receives this request, it
+loads the query and executes it, knowing it was already validated.
 
 ## Debugging Tips
 
@@ -153,7 +177,6 @@ formatError: error => ({
   stack: error.stack
 })
 ```
-
 
 [`GraphQL.js`]: https://github.com/graphql/graphql-js
 [`formatError`]: https://github.com/graphql/graphql-js/blob/master/src/error/formatError.js

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ new GraphQLObjectType({
 
 ## Persisted Documents
 
-Putting control of the query in to clients hands is one of the primary benefits
+Putting control of the query into clients' hands is one of the primary benefits
 of GraphQL. Though when this is deployed to production naively, it is possible to
 end up uploading and revalidating the same document text across all clients of a
 particular deployment. It can even be problematic within a single client, sending


### PR DESCRIPTION
This adds support to express-graphql for GraphQL persisted documents. This is a feature we have discussed in ad-hoc ways since open sourcing GraphQL, and are now attempting to demonstrate more concretely. Persisted documents are foundational to how we use GraphQL at Facebook, especially for our mobile clients. Additional background context is being added to the README.

The goal in adding this support to express-graphql is to provide a clear example of how this idea can be implemented which should allow it to be translated to any other GraphQL server middleware or implementation.

Notes:
- persistValidatedDocument and providing the /persist endpoint is still a nascent idea, that needs the most scrutiny. Then once its settled, tests.
