### PR TITLE
Context defaulting to request

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ import type { Request, Response } from 'express';
 
 
 /**
- * Used to configure the graphQLHTTP middleware by providing a schema
+ * Used to configure the graphqlHTTP middleware by providing a schema
  * and other configuration options.
  *
  * Options can be provided as an Object, a Promise for an Object, or a Function
@@ -89,7 +89,7 @@ export default function graphqlHTTP(options: Options): Middleware {
 
   return (request: Request, response: Response) => {
     // Higher scoped variables are referred to at various stages in the
-    // asyncronous state machine below.
+    // asynchronous state machine below.
     let schema;
     let context;
     let rootValue;
@@ -103,7 +103,7 @@ export default function graphqlHTTP(options: Options): Middleware {
     let validationRules;
 
     // Promises are used as a mechanism for capturing any thrown errors during
-    // the asyncronous process below.
+    // the asynchronous process below.
 
     // Resolve the Options to get OptionsData.
     return new Promise(resolve => {
@@ -130,7 +130,7 @@ export default function graphqlHTTP(options: Options): Middleware {
 
       // Collect information from the options data object.
       schema = optionsData.schema;
-      context = optionsData.context;
+      context = optionsData.context || request;
       rootValue = optionsData.rootValue;
       pretty = optionsData.pretty;
       graphiql = optionsData.graphiql;


### PR DESCRIPTION
This PR slightly tweaks the default behavior so that by default the express request is passed as the context object, and updates a decent amount of the README documentation.

The rationale is to make it simpler to support express middleware, in particular authentication. Most express middleware works similarly - some extra field is tacked onto `request`. This is convenient for express developers because the `request` object is accessible from every route handler. The graphql equivalent of a route handler is a resolver, so if the `request` object is simply available to every resolver, express middleware is generally usable without having to alter the graphqlHTTP route handler itself. I think this is an "expressy" thing to do, even if it does not quite aesthetically jive with the deep love of immutability reflected in graphql itself.

Middleware that behaves this way & can now be used without altering the graphqlHTTP method call:
* express-session tacks on request.session
* express-jwt tacks on request.user
* passport tacks on request.user
* multer tacks on request.file or request.files

Note the "advanced scenario" docs of authentication are simpler now - you do not have to pass a function to the graphqlHTTP method, you can just use the same call that was in the "intro".

This is backward compatible unless you wrote code that relies on having a falsy context which seems unlikely.

Documentation changes are mostly self-explanatory. The change to using port 4000 in the example is so that it doesn't conflict by default with create-react-app - a small tweak but this may avoid little bits of confusion. Using 'require' instead of 'import' is a bit sad but preferable for now because it means that this code works with node out of the box - most node developers are not transpiling.
