### PR TITLE
support for adding optional error handling function before returning …

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ The `graphqlHTTP` function accepts the following options:
   * **`graphiql`**: If `true`, may present [GraphiQL][] when loaded directly
     from a browser (a useful tool for debugging and exploration).
 
+  * **`handleErrors`**: An optional function which will be used to handle any errors
+    encountered by fulfilling a GraphQL operation. If no function is provided, Errors
+    will default to normal behavior and return in `errors` array.
+
 
 ## Debugging
 

--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,13 @@ export type OptionsData = {
    * A boolean to optionally enable GraphiQL mode.
    */
   graphiql?: ?boolean,
+
+  /**
+   * An optional function which will be used to handle any errors encountered
+   * by fulfilling a GraphQL operation. If no function is provided, Errors will
+   * be handled by default.
+   */
+  handleErrors?: ?Function,
 };
 
 type Middleware = (request: Request, response: Response) => Promise<void>;
@@ -101,6 +108,7 @@ export default function graphqlHTTP(options: Options): Middleware {
     let variables;
     let operationName;
     let validationRules;
+    let handleErrorsFn;
 
     // Promises are used as a mechanism for capturing any thrown errors during
     // the asyncronous process below.
@@ -135,6 +143,7 @@ export default function graphqlHTTP(options: Options): Middleware {
       pretty = optionsData.pretty;
       graphiql = optionsData.graphiql;
       formatErrorFn = optionsData.formatError;
+      handleErrorsFn = optionsData.handleErrors;
 
       validationRules = specifiedRules;
       if (optionsData.validationRules) {
@@ -233,6 +242,7 @@ export default function graphqlHTTP(options: Options): Middleware {
       // Format any encountered errors.
       if (result && result.errors) {
         result.errors = result.errors.map(formatErrorFn || formatError);
+        if (handleErrorsFn) { handleErrorsFn(result, response); }
       }
       // If allowed to show GraphiQL, present it instead of JSON.
       if (showGraphiQL) {


### PR DESCRIPTION
# 116 the ability to modify responses and the status codes based on errors.

Gives the option to handle errors from responses before sending back the request. If you do not want to handle the errors, you can omit the optional `handleErrors` function and it will behave as normal. Since it is optional, it shouldn't break existing functionality. 
