### PR TITLE
Re-enable express etag support

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "multer": "1.1.0",
     "raw-body": "2.1.6",
     "sane": "1.3.4",
+    "sinon": "^1.17.5",
     "supertest": "1.0.1",
     "supertest-as-promised": "2.0.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -241,12 +241,12 @@ export default function graphqlHTTP(options: Options): Middleware {
           operationName, result
         });
         response.setHeader('Content-Type', 'text/html; charset=utf-8');
-        response.end(data);
+        sendResponse(response, data);
       } else {
         // Otherwise, present JSON directly.
         const data = JSON.stringify(result, null, pretty ? 2 : 0);
         response.setHeader('Content-Type', 'application/json; charset=utf-8');
-        response.end(data);
+        sendResponse(response, data);
       }
     });
   };
@@ -294,4 +294,16 @@ function canDisplayGraphiQL(
   // Allowed to show GraphiQL if not requested as raw and this request
   // prefers HTML over JSON.
   return !raw && accepts(request).types([ 'json', 'html' ]) === 'html';
+}
+
+/**
+ * Helper function for sending the response data. Use response.send it method
+ * exists (express), otherwise use response.end (connect).
+ */
+function sendResponse(response: Response, data: string): void {
+  if (typeof response.send === 'function') {
+    response.send(data);
+  } else {
+    response.end(data);
+  }
 }


### PR DESCRIPTION
The express `response.send` provides some extra functionality, such as adding an ETag header. https://github.com/graphql/express-graphql/commit/48e6659945477bd706fe22173f450c16eddd5bf5 removed `.send` in favor of `.end` in order to support connect. This PR adds a helper function, `sendResponse`, which calls `response.send` if that method exists (i.e. the server is express), otherwise fallback to `response.end`.

In order to test that the correct method is called, I added sinon as a devDependency and a single test that uses a spy to verify that `send` is called when the server is express. 

This fixes #115
