### PR TITLE
Export parseBody

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ import { renderGraphiQL } from './renderGraphiQL';
 
 import type { Request, Response } from 'express';
 
+export { parseBody };
 
 /**
  * Used to configure the graphqlHTTP middleware by providing a schema


### PR DESCRIPTION
`parseBody` handles complexities in deriving the params from POST requests. It should be exposed to allow for applications and middleware to have access to params like "query" and "operationName" without having to reimplement the logic already defined in `parseBody`.
