### PR TITLE
update flow to 0.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-babel": "3.2.0",
     "express": "4.13.4",
     "express3": "*",
-    "flow-bin": "0.25.0",
+    "flow-bin": "^0.33.0",
     "graphql": "0.7.0",
     "isparta": "4.0.0",
     "mocha": "2.5.3",

--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -19,8 +19,8 @@ type GraphiQLData = {
 const GRAPHIQL_VERSION = '0.7.1';
 
 // Ensures string values are save to be used within a <script> tag.
-function safeSerialize(data) {
-  return data ? JSON.stringify(data).replace(/\//g, '\\/') : null;
+function safeSerialize(data): string {
+  return data ? JSON.stringify(data).replace(/\//g, '\\/') : 'null';
 }
 
 /**


### PR DESCRIPTION
Explicitly return string in `safeSerialize` to avoid `null` cannot be coerced to `string` error
