### PR TITLE
Adds getGraphQLParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ new GraphQLObjectType({
 ```
 
 
+## Other Exports
+
+**`getGraphQLParams(request: Request): Promise<GraphQLParams>`**
+
+Given an HTTP Request, this returns a Promise for the parameters relevant to
+running a GraphQL request. This function is used internally to handle the
+incoming request, you may use it directly for building other similar services.
+
+
 ## Debugging Tips
 
 During development, it's useful to get more information from errors, such as


### PR DESCRIPTION
This exposes a new method `getGraphQLParams` which converts from a Request instance (a Stream) to a Promise for the parameters relevant to fulfilling a GraphQL request.

In doing so, this also makes the type for "Request" more restrictive, which results in some edge case corrections in the source.

Fixes #121 