### PR TITLE
500 when response.data is null.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -234,23 +234,31 @@ export default function graphqlHTTP(options: Options): Middleware {
       response.statusCode = error.status || 500;
       return { errors: [ error ] };
     }).then(result => {
+      // If no data was included in the result, that indicates a runtime query
+      // error, indicate as such with a generic status code.
+      // Note: Information about the error itself will still be contained in
+      // the resulting JSON payload.
+      // http://facebook.github.io/graphql/#sec-Data
+      if (result && result.data === null) {
+        response.statusCode = 500;
+      }
       // Format any encountered errors.
       if (result && result.errors) {
         result.errors = result.errors.map(formatErrorFn || formatError);
       }
       // If allowed to show GraphiQL, present it instead of JSON.
       if (showGraphiQL) {
-        const data = renderGraphiQL({
+        const payload = renderGraphiQL({
           query, variables,
           operationName, result
         });
         response.setHeader('Content-Type', 'text/html; charset=utf-8');
-        sendResponse(response, data);
+        sendResponse(response, payload);
       } else {
         // Otherwise, present JSON directly.
-        const data = JSON.stringify(result, null, pretty ? 2 : 0);
+        const payload = JSON.stringify(result, null, pretty ? 2 : 0);
         response.setHeader('Content-Type', 'application/json; charset=utf-8');
-        sendResponse(response, data);
+        sendResponse(response, payload);
       }
     });
   };


### PR DESCRIPTION
This matches the described spec behavior that when response.data is null, that indicates a query error. This happens when a top field is Non-Null and produces an error. In that case there is no data for the query and a 500 is an appropriate response status.

Suggested in #118