### PR TITLE
Custom context function with request object as an argument

### DIFF
--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -381,6 +381,36 @@ describe('test harness', () => {
         });
       });
 
+      it('Allows passing in a context function', async () => {
+        const app = server();
+
+        // Middleware that adds req.foo to every request
+        app.use((req, res, next) => {
+          req.foo = 'bar';
+          next();
+        });
+
+        app.use(urlString(), graphqlHTTP({
+          schema: TestSchema,
+          context: req => `dotFoo:${req.foo}`
+        }));
+
+        const response = await request(app)
+          .get(urlString({
+            operationName: 'TestQuery',
+            query: `
+              query TestQuery { context }
+            `
+          }));
+
+        expect(response.status).to.equal(200);
+        expect(JSON.parse(response.text)).to.deep.equal({
+          data: {
+            context: 'dotFoo:bar'
+          }
+        });
+      });
+
       it('Allows returning an options Promise', async () => {
         const app = server();
 

--- a/src/index.js
+++ b/src/index.js
@@ -130,11 +130,18 @@ export default function graphqlHTTP(options: Options): Middleware {
 
       // Collect information from the options data object.
       schema = optionsData.schema;
-      context = optionsData.context || request;
       rootValue = optionsData.rootValue;
       pretty = optionsData.pretty;
       graphiql = optionsData.graphiql;
       formatErrorFn = optionsData.formatError;
+
+      if (typeof optionsData.context === 'function') {
+        context = optionsData.context(request);
+      } else if (optionsData.context) {
+        context = optionsData.context;
+      } else {
+        context = request;
+      }
 
       validationRules = specifiedRules;
       if (optionsData.validationRules) {


### PR DESCRIPTION
Currently, we can only use either the request object or a custom context object. By accepting a function for context, we can use both at the same time.

Note: `npm install` fails so I couldn't run tests