### PR TITLE
Update graphql dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "express": "4.14.0",
     "express3": "*",
     "flow-bin": "0.36.0",
-    "graphql": "0.8.1",
+    "graphql": "0.8.2",
     "isparta": "4.0.0",
     "mocha": "3.2.0",
     "multer": "1.2.1",


### PR DESCRIPTION
Refraining from dropping the "-b" from the "0.8.0-b" part of the peer
dependency so as not to cause unnecessary breakage for people's set-ups.