### PR TITLE
Pass request to extensionFn

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,8 @@ function graphqlHTTP(options: Options): Middleware {
           document: documentAST,
           variables,
           operationName,
-          result
+          result,
+          request
         })).then(extensions => {
           if (extensions && typeof extensions === 'object') {
             (result: any).extensions = extensions;


### PR DESCRIPTION
in my project, i remove fields in the extension function based on the requesting user. since it is common to store the user on the request object, i thought this might be useful for others. i do not remove the fields in the resolve function so that child-resolves have access to a fully-hydrated parent resource.