### PR TITLE
Allow to pass function that returns Promise as a rootValue option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ The `graphqlHTTP` function accepts the following options:
     quite useful. You may or may not want it in production.
 
   * **`rootValue`**: A value to pass as the `rootValue` to the `graphql()`
-    function from [`GraphQL.js`][].
+    function from [`GraphQL.js`][]. Can be provided as an object, a Promise for
+    an object, or a Function that returns an object or a Promise for an object.
 
   * **`context`**: A value to pass as the `context` to the `graphql()`
     function from [`GraphQL.js`][]. If `context` is not provided, the

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -63,6 +63,12 @@ const QueryRootType = new GraphQLObjectType({
         return (context: any).foo;
       },
     },
+    rootValueField: {
+      type: GraphQLString,
+      resolve: obj => {
+        return (obj: any).rootValueField;
+      },
+    }
   }
 });
 
@@ -1574,6 +1580,73 @@ describe('test harness', () => {
         expect(response.type).to.equal('application/json');
         expect(response.text).to.equal(
           '{"data":{"test":"Hello World"},"extensions":{"eventually":42}}'
+        );
+      });
+    });
+
+
+    describe('Custom rootValue', () => {
+
+      it('allows to supply rootValue as an object', async () => {
+        const app = server();
+
+        app.use(urlString(), graphqlHTTP({
+          schema: TestSchema,
+          rootValue: {rootValueField: 'Test Value'},
+        }));
+
+        const response = await request(app)
+          .get(urlString({ query: '{rootValueField}', raw: '' }))
+          .set('Accept', 'text/html');
+
+        expect(response.status).to.equal(200);
+        expect(response.type).to.equal('application/json');
+        expect(response.text).to.equal(
+          '{"data":{"rootValueField":"Test Value"}}'
+        );
+      });
+
+      it('allows to supply rootValue as a Promise for an object', async () => {
+        const app = server();
+
+        app.use(urlString(), graphqlHTTP({
+          schema: TestSchema,
+          rootValue: new Promise(resolve => resolve({
+            rootValueField: 'Test Value'
+          })),
+        }));
+
+        const response = await request(app)
+          .get(urlString({ query: '{rootValueField}', raw: '' }))
+          .set('Accept', 'text/html');
+
+        expect(response.status).to.equal(200);
+        expect(response.type).to.equal('application/json');
+        expect(response.text).to.equal(
+          '{"data":{"rootValueField":"Test Value"}}'
+        );
+      });
+
+      it('allows to supply rootValue as Function that returns a Promise for an object', async () => {
+        const app = server();
+
+        app.use(urlString(), graphqlHTTP({
+          schema: TestSchema,
+          rootValue() {
+            return new Promise(resolve => resolve({
+              rootValueField: 'Test Value'
+            }));
+          }
+        }));
+
+        const response = await request(app)
+          .get(urlString({query: '{rootValueField}', raw: ''}))
+          .set('Accept', 'text/html');
+
+        expect(response.status).to.equal(200);
+        expect(response.type).to.equal('application/json');
+        expect(response.text).to.equal(
+          '{"data":{"rootValueField":"Test Value"}}'
         );
       });
     });

--- a/src/index.js
+++ b/src/index.js
@@ -63,8 +63,10 @@ export type OptionsData = {
 
   /**
    * An object to pass as the rootValue to the graphql() function.
+   * Can be provided as an object, a Promise for an object, or a Function that
+   * returns an object or a Promise for an object.
    */
-  rootValue?: ?mixed,
+  rootValue?: ?RootValue,
 
   /**
    * A boolean to configure whether the output should be pretty-printed.
@@ -101,6 +103,13 @@ export type OptionsData = {
    */
   graphiql?: ?boolean,
 };
+
+/**
+ * RootValue can be provided as an object, a Promise for an object,
+ * or a Function that returns an object or a Promise for an object.
+ */
+export type RootValue =
+  ((info: RequestInfo) => mixed) | mixed;
 
 /**
  * All information about a GraphQL request.
@@ -261,21 +270,34 @@ function graphqlHTTP(options: Options): Middleware {
           );
         }
       }
-      // Perform the execution, reporting any errors creating the context.
-      try {
-        return execute(
-          schema,
-          documentAST,
-          rootValue,
-          context,
-          variables,
-          operationName
+
+      return new Promise(resolve => {
+        resolve(
+          typeof rootValue === 'function' ?
+            rootValue({
+              document: documentAST,
+              variables,
+              operationName,
+              result: null,
+            }) : rootValue
         );
-      } catch (contextError) {
-        // Return 400: Bad Request if any execution context errors exist.
-        response.statusCode = 400;
-        return { errors: [ contextError ] };
-      }
+      }).then(rootValueData => {
+        // Perform the execution, reporting any errors creating the context.
+        try {
+          return execute(
+            schema,
+            documentAST,
+            rootValueData,
+            context,
+            variables,
+            operationName
+          );
+        } catch (contextError) {
+          // Return 400: Bad Request if any execution context errors exist.
+          response.statusCode = 400;
+          return { errors: [ contextError ] };
+        }
+      });
     }).then(result => {
       // Collect and apply any metadata extensions if a function was provided.
       // http://facebook.github.io/graphql/#sec-Response-Format


### PR DESCRIPTION
This functionality is required when you need different `rootValue` depending on the query. In our case, we are working on a GraphQL proxy that needs to pass a query to the original GraphQL server and provide its response as the `rootValue`.
