### PR TITLE
Add compatibility with Restify

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,7 +39,7 @@
   },
 
   "rules": {
-    "babel/no-await-in-loop": 2,
+    "no-await-in-loop": 2,
 
     "flowtype/space-after-type-colon": [2, "always"],
     "flowtype/space-before-type-colon": [2, "never"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,8 @@
 
   "env": {
     "es6": true,
-    "node": true
+    "node": true,
+    "mocha": true
   },
 
   "ecmaFeatures": {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ app.listen(4000);
 
 In restify the `.use` method is reserved to common handlers so you have to manually register methods (GET, POST, etc) multiple times even for the same endpoint.
 
-If you just need GraphQL to listen to POST request just mount `express-graphql` like so:
+If you just need GraphQL with POST requests, just mount `express-graphql` like so:
 
 ```js
 const restify = require('restify');
@@ -52,9 +52,9 @@ app.post('/graphql', graphqlHTTP({
 app.listen(4000);
 ```
 
-NOTE: Registering GraphQL on POST doesn't allow you to serve GraphiQL since this is a visual HTML tool served through the browser, hence via GET.
+NOTE: Registering GraphQL on POST doesn't allow you to serve GraphiQL since this is an interface accesible through the browser, hence via a GET request.
 
-If you do want to present GraphiQL when the GraphQL endpoint is loaded in a browser then all you need to do is register a GET method:
+If you do want to present the GraphiQL interface when the GraphQL endpoint is loaded in a browser then all you need to do is to register a GET method:
 
 ```js
 const restify = require('restify');
@@ -70,7 +70,26 @@ app.get('/graphql', graphqlHTTP({
 app.listen(4000);
 ```
 
-Having both the POST and the GET method listeners on the same endpoint will not cause any issue and will allow you to receive GraphQL queries with GET via query params and with POST via a payload in addition to optionally display GraphiQL when accessing `/graphql` through the browser.
+Having both the POST and the GET methods registered on the same endpoint will not cause any issue and will allow you to receive GraphQL queries through GET request using query params and POST requests using a payload in addition to optionally serve the GraphiQL interface when accessing `/graphql` from the browser; here is the full configuration:
+
+```js
+const restify = require('restify');
+const graphqlHTTP = require('express-graphql');
+
+const app = restify.createServer();
+
+app.post('/graphql', graphqlHTTP({
+  schema: MyGraphQLSchema,
+  graphiql: false
+}));
+
+app.get('/graphql', graphqlHTTP({
+  schema: MyGraphQLSchema,
+  graphiql: true // set it to false to disable the GraphiQL interface
+}));
+
+app.listen(4000);
+```
 
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GraphQL HTTP Server Middleware
 [![Build Status](https://travis-ci.org/graphql/express-graphql.svg?branch=master)](https://travis-ci.org/graphql/express-graphql)
 [![Coverage Status](https://coveralls.io/repos/graphql/express-graphql/badge.svg?branch=master&service=github)](https://coveralls.io/github/graphql/express-graphql?branch=master)
 
-Create a GraphQL HTTP server with any HTTP web framework that supports connect styled middleware, including [Connect](https://github.com/senchalabs/connect) itself and [Express](http://expressjs.com).
+Create a GraphQL HTTP server with any HTTP web framework that supports connect styled middleware, including [Connect](https://github.com/senchalabs/connect) itself, [Express](http://expressjs.com) and [Restify](http://restify.com/).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Create a GraphQL HTTP server with any HTTP web framework that supports connect s
 npm install --save express-graphql
 ```
 
-Then mount `express-graphql` as a route handler:
+
+## Simple Setup
+
+Just mount `express-graphql` as a route handler:
 
 ```js
 const express = require('express');
@@ -27,6 +30,48 @@ app.use('/graphql', graphqlHTTP({
 
 app.listen(4000);
 ```
+
+
+## Setup with Restify
+
+In restify the `.use` method is reserved to common handlers so you have to manually register methods (GET, POST, etc) multiple times even for the same endpoint.
+
+If you just need GraphQL to listen to POST request just mount `express-graphql` like so:
+
+```js
+const restify = require('restify');
+const graphqlHTTP = require('express-graphql');
+
+const app = restify.createServer();
+
+app.post('/graphql', graphqlHTTP({
+  schema: MyGraphQLSchema,
+  graphiql: false
+}));
+
+app.listen(4000);
+```
+
+NOTE: Registering GraphQL on POST doesn't allow you to serve GraphiQL since this is a visual HTML tool served through the browser, hence via GET.
+
+If you do want to present GraphiQL when the GraphQL endpoint is loaded in a browser then all you need to do is register a GET method:
+
+```js
+const restify = require('restify');
+const graphqlHTTP = require('express-graphql');
+
+const app = restify.createServer();
+
+app.get('/graphql', graphqlHTTP({
+  schema: MyGraphQLSchema,
+  graphiql: true
+}));
+
+app.listen(4000);
+```
+
+Having both the POST and the GET method listeners on the same endpoint will not cause any issue and will allow you to receive GraphQL queries with GET via query params and with POST via a payload in addition to optionally display GraphiQL when accessing `/graphql` through the browser.
+
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -111,8 +111,6 @@ The `graphqlHTTP` function accepts the following options:
     function from [`GraphQL.js`][]. If `context` is not provided, the
     `request` object is passed as the context.
 
-  * **`pretty`**: If `true`, any JSON response will be pretty-printed.
-
   * **`formatError`**: An optional function which will be used to format any
     errors produced by fulfilling a GraphQL operation. If no function is
     provided, GraphQL's default spec-compliant [`formatError`][] function will be used.

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "isparta": "4.0.0",
     "mocha": "3.3.0",
     "multer": "1.3.0",
+    "restify": "4.3.0",
     "sane": "1.6.0",
     "sinon": "2.2.0",
     "supertest": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "keywords": [
     "express",
+    "restify",
     "connect",
     "http",
     "graphql",

--- a/resources/interfaces/express.js
+++ b/resources/interfaces/express.js
@@ -11,4 +11,5 @@ declare class Response {
   status: (code: Number) => Response;
   set: (field: String, value: String) => Response;
   send: (body: String) => void;
+  json: (body: Object) => void;
 }

--- a/resources/interfaces/mocha.js
+++ b/resources/interfaces/mocha.js
@@ -1,0 +1,4 @@
+/* @flow */
+/* Flow declarations for Mocha */
+/* eslint-disable no-unused-vars */
+declare var beforeEach: Function;

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -9,7 +9,7 @@
  */
 
 // 80+ char lines are useful in describe/it, so ignore in this file.
-// Also ignore no-unused-expressions rule as chai 'expect' sintax violates it.
+// Also ignore no-unused-expressions rule as chai 'expect' syntax violates it.
 /* eslint-disable max-len */
 /* eslint-disable no-unused-expressions */
 

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -1255,8 +1255,7 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
       it('Do not execute a query if it do not pass the custom validation.', async() => {
         const config = [ urlString(), graphqlHTTP({
           schema: TestSchema,
-          validationRules: [ AlwaysInvalidRule ],
-          pretty: true,
+          validationRules: [ AlwaysInvalidRule ]
         }) ];
         if (name === 'restify') {
           app.get(...config);

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -594,7 +594,7 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
       });
 
       describe('allows for pre-parsed POST', () => {
-        it('bodies', async function () {
+        it('bodies', async () => {
           // Note: this is not the only way to handle file uploads with GraphQL,
           // but it is terse and illustrative of using express-graphql and multer
           // together.

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -15,14 +15,11 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import sinon from 'sinon';
 import { stringify } from 'querystring';
-import url from 'url';
 import zlib from 'zlib';
 import multer from 'multer';
 import bodyParser from 'body-parser';
 import request from 'supertest-as-promised';
-import connect from 'connect';
-import express4 from 'express'; // modern
-import express3 from 'express3'; // old but commonly still used
+import express4 from 'express'; // current version 4
 import {
   GraphQLSchema,
   GraphQLObjectType,
@@ -115,9 +112,7 @@ describe('test harness', () => {
 });
 
 ([
-  [ connect, 'connect' ],
-  [ express4, 'express-modern' ],
-  [ express3, 'express-old' ]
+  [ express4, 'express-current' ]
 ])
 .forEach(([ server, name ]) => {
   describe(`GraphQL-HTTP tests for ${name}`, () => {
@@ -828,74 +823,6 @@ describe('test harness', () => {
         } else {
           expect(spySend.calledOnce);
         }
-      });
-    });
-
-    describe('Pretty printing', () => {
-      it('supports pretty printing', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          pretty: true
-        }));
-
-        const response = await request(app)
-          .get(urlString({
-            query: '{test}'
-          }));
-
-        expect(response.text).to.equal(
-          '{\n' +
-          '  "data": {\n' +
-          '    "test": "Hello World"\n' +
-          '  }\n' +
-          '}'
-        );
-      });
-
-      it('supports pretty printing configured by request', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP(req => {
-          return {
-            schema: TestSchema,
-            pretty: ((url.parse(req.url, true) || {}).query || {}).pretty === '1'
-          };
-        }));
-
-        const defaultResponse = await request(app)
-          .get(urlString({
-            query: '{test}'
-          }));
-
-        expect(defaultResponse.text).to.equal(
-          '{"data":{"test":"Hello World"}}'
-        );
-
-        const prettyResponse = await request(app)
-          .get(urlString({
-            query: '{test}',
-            pretty: 1
-          }));
-
-        expect(prettyResponse.text).to.equal(
-          '{\n' +
-          '  "data": {\n' +
-          '    "test": "Hello World"\n' +
-          '  }\n' +
-          '}'
-        );
-
-        const unprettyResponse = await request(app)
-          .get(urlString({
-            query: '{test}',
-            pretty: 0
-          }));
-
-        expect(unprettyResponse.text).to.equal(
-          '{"data":{"test":"Hello World"}}'
-        );
       });
     });
 

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -19,7 +19,8 @@ import zlib from 'zlib';
 import multer from 'multer';
 import bodyParser from 'body-parser';
 import request from 'supertest-as-promised';
-import express4 from 'express'; // current version 4
+import express4 from 'express';
+import restify4 from 'restify';
 import {
   GraphQLSchema,
   GraphQLObjectType,
@@ -112,692 +113,586 @@ describe('test harness', () => {
 });
 
 ([
-  [ express4, 'express-current' ]
+  [ express4, 'express' ],
+  [ restify4, 'restify' ]
 ])
 .forEach(([ server, name ]) => {
   describe(`GraphQL-HTTP tests for ${name}`, () => {
+    let app;
+    beforeEach(() => {
+      app = name === 'restify' ? server.createServer() : server();
+    });
+
     describe('GET functionality', () => {
-      it('allows GET with query param', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
-        }));
-
-        const response = await request(app)
-          .get(urlString({
-            query: '{test}'
+      describe('Without context', () => {
+        beforeEach(() => {
+          app.get(urlString(), graphqlHTTP({
+            schema: TestSchema
           }));
-
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello World"}}'
-        );
-      });
-
-      it('allows GET with variable values', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
-        }));
-
-        const response = await request(app)
-          .get(urlString({
-            query: 'query helloWho($who: String){ test(who: $who) }',
-            variables: JSON.stringify({ who: 'Dolly' })
-          }));
-
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello Dolly"}}'
-        );
-      });
-
-      it('allows GET with operation name', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP(() => ({
-          schema: TestSchema
-        })));
-
-        const response = await request(app)
-          .get(urlString({
-            query: `
-              query helloYou { test(who: "You"), ...shared }
-              query helloWorld { test(who: "World"), ...shared }
-              query helloDolly { test(who: "Dolly"), ...shared }
-              fragment shared on QueryRoot {
-                shared: test(who: "Everyone")
-              }
-            `,
-            operationName: 'helloWorld'
-          }));
-
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: {
-            test: 'Hello World',
-            shared: 'Hello Everyone',
-          }
         });
-      });
 
-      it('Reports validation errors', async () => {
-        const app = server();
+        it('allows GET with query param', async () => {
+          const response = await request(app)
+            .get(urlString({
+              query: '{test}'
+            }));
 
-        app.use(urlString(), graphqlHTTP({ schema: TestSchema }));
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello World"}}'
+          );
+        });
 
-        const response = await request(app)
-          .get(urlString({
-            query: '{ test, unknownOne, unknownTwo }'
-          }));
+        it('allows GET with variable values', async () => {
+          const response = await request(app)
+            .get(urlString({
+              query: 'query helloWho($who: String){ test(who: $who) }',
+              variables: JSON.stringify({ who: 'Dolly' })
+            }));
 
-        expect(response.status).to.equal(400);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [
-            {
-              message: 'Cannot query field "unknownOne" on type "QueryRoot".',
-              locations: [ { line: 1, column: 9 } ]
-            },
-            {
-              message: 'Cannot query field "unknownTwo" on type "QueryRoot".',
-              locations: [ { line: 1, column: 21 } ]
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello Dolly"}}'
+          );
+        });
+
+        it('allows GET with operation name', async () => {
+          const response = await request(app)
+            .get(urlString({
+              query: `
+                query helloYou { test(who: "You"), ...shared }
+                query helloWorld { test(who: "World"), ...shared }
+                query helloDolly { test(who: "Dolly"), ...shared }
+                fragment shared on QueryRoot {
+                  shared: test(who: "Everyone")
+                }
+              `,
+              operationName: 'helloWorld'
+            }));
+
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: {
+              test: 'Hello World',
+              shared: 'Hello Everyone',
             }
-          ]
+          });
         });
-      });
 
-      it('Errors when missing operation name', async () => {
-        const app = server();
+        it('Reports validation errors', async () => {
+          const response = await request(app)
+            .get(urlString({
+              query: '{ test, unknownOne, unknownTwo }'
+            }));
 
-        app.use(urlString(), graphqlHTTP({ schema: TestSchema }));
-
-        const response = await request(app)
-          .get(urlString({
-            query: `
-              query TestQuery { test }
-              mutation TestMutation { writeTest { test } }
-            `
-          }));
-
-        expect(response.status).to.equal(400);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [
-            { message: 'Must provide operation name if query contains multiple operations.' }
-          ]
+          expect(response.status).to.equal(400);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [
+              {
+                message: 'Cannot query field "unknownOne" on type "QueryRoot".',
+                locations: [ { line: 1, column: 9 } ]
+              },
+              {
+                message: 'Cannot query field "unknownTwo" on type "QueryRoot".',
+                locations: [ { line: 1, column: 21 } ]
+              }
+            ]
+          });
         });
-      });
 
-      it('Errors when sending a mutation via GET', async () => {
-        const app = server();
+        it('Errors when missing operation name', async () => {
+          const response = await request(app)
+            .get(urlString({
+              query: `
+                query TestQuery { test }
+                mutation TestMutation { writeTest { test } }
+              `
+            }));
 
-        app.use(urlString(), graphqlHTTP({ schema: TestSchema }));
-
-        const response = await request(app)
-          .get(urlString({
-            query: 'mutation TestMutation { writeTest { test } }'
-          }));
-
-        expect(response.status).to.equal(405);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [
-            { message: 'Can only perform a mutation operation from a POST request.' }
-          ]
+          expect(response.status).to.equal(400);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [
+              { message: 'Must provide operation name if query contains multiple operations.' }
+            ]
+          });
         });
-      });
 
-      it('Errors when selecting a mutation within a GET', async () => {
-        const app = server();
+        it('Errors when sending a mutation via GET', async () => {
+          const response = await request(app)
+            .get(urlString({
+              query: 'mutation TestMutation { writeTest { test } }'
+            }));
 
-        app.use(urlString(), graphqlHTTP({ schema: TestSchema }));
-
-        const response = await request(app)
-          .get(urlString({
-            operationName: 'TestMutation',
-            query: `
-              query TestQuery { test }
-              mutation TestMutation { writeTest { test } }
-            `
-          }));
-
-        expect(response.status).to.equal(405);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [
-            { message: 'Can only perform a mutation operation from a POST request.' }
-          ]
+          expect(response.status).to.equal(405);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [
+              { message: 'Can only perform a mutation operation from a POST request.' }
+            ]
+          });
         });
-      });
 
-      it('Allows a mutation to exist within a GET', async () => {
-        const app = server();
+        it('Errors when selecting a mutation within a GET', async () => {
+          const response = await request(app)
+            .get(urlString({
+              operationName: 'TestMutation',
+              query: `
+                query TestQuery { test }
+                mutation TestMutation { writeTest { test } }
+              `
+            }));
 
-        app.use(urlString(), graphqlHTTP({ schema: TestSchema }));
-
-        const response = await request(app)
-          .get(urlString({
-            operationName: 'TestQuery',
-            query: `
-              mutation TestMutation { writeTest { test } }
-              query TestQuery { test }
-            `
-          }));
-
-        expect(response.status).to.equal(200);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: {
-            test: 'Hello World'
-          }
+          expect(response.status).to.equal(405);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [
+              { message: 'Can only perform a mutation operation from a POST request.' }
+            ]
+          });
         });
-      });
 
-      it('Allows passing in a context', async () => {
-        const app = server();
+        it('Allows a mutation to exist within a GET', async () => {
+          const response = await request(app)
+            .get(urlString({
+              operationName: 'TestQuery',
+              query: `
+                mutation TestMutation { writeTest { test } }
+                query TestQuery { test }
+              `
+            }));
 
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          context: 'testValue'
-        }));
+          expect(response.status).to.equal(200);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: {
+              test: 'Hello World'
+            }
+          });
+        });
+      })
 
-        const response = await request(app)
-          .get(urlString({
-            operationName: 'TestQuery',
-            query: `
-              query TestQuery { context }
-            `
-          }));
-
-        expect(response.status).to.equal(200);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: {
+      describe('With context', () => {
+        it('Allows passing in a context', async () => {
+          app.get(urlString(), graphqlHTTP({
+            schema: TestSchema,
             context: 'testValue'
-          }
-        });
-      });
-
-      it('Uses request as context by default', async () => {
-        const app = server();
-
-        // Middleware that adds req.foo to every request
-        app.use((req, res, next) => {
-          req.foo = 'bar';
-          next();
-        });
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
-        }));
-
-        const response = await request(app)
-          .get(urlString({
-            operationName: 'TestQuery',
-            query: `
-              query TestQuery { contextDotFoo }
-            `
           }));
 
-        expect(response.status).to.equal(200);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: {
-            contextDotFoo: 'bar'
-          }
+          const response = await request(app)
+            .get(urlString({
+              operationName: 'TestQuery',
+              query: `
+                query TestQuery { context }
+              `
+            }));
+
+          expect(response.status).to.equal(200);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: {
+              context: 'testValue'
+            }
+          });
         });
-      });
 
-      it('Allows returning an options Promise', async () => {
-        const app = server();
+        it('Uses request as context by default', async () => {
+          // Middleware that adds req.foo to every request
+          app.use((req, res, next) => {
+            req.foo = 'bar';
+            next();
+          });
 
-        app.use(urlString(), graphqlHTTP(() => Promise.resolve({
-          schema: TestSchema,
-        })));
-
-        const response = await request(app)
-          .get(urlString({
-            query: '{test}'
+          app.get(urlString(), graphqlHTTP({
+            schema: TestSchema
           }));
 
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello World"}}'
-        );
-      });
+          const response = await request(app)
+            .get(urlString({
+              operationName: 'TestQuery',
+              query: `
+                query TestQuery { contextDotFoo }
+              `
+            }));
 
-      it('Catches errors thrown from options function', async () => {
-        const app = server();
+          expect(response.status).to.equal(200);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: {
+              contextDotFoo: 'bar'
+            }
+          });
+        });
+      })
 
-        app.use(urlString(), graphqlHTTP(() => {
-          throw new Error('I did something wrong');
-        }));
+      describe('With options', () => {
+        it('Allows returning an options Promise', async () => {
+          app.get(urlString(), graphqlHTTP(() => Promise.resolve({
+            schema: TestSchema,
+          })));
 
-        const response = await request(app)
-          .get(urlString({
-            query: '{test}'
+          const response = await request(app)
+            .get(urlString({
+              query: '{test}'
+            }));
+
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello World"}}'
+          );
+        });
+
+        it('Catches errors thrown from options function', async () => {
+          app.get(urlString(), graphqlHTTP(() => {
+            throw new Error('I did something wrong');
           }));
 
-        expect(response.status).to.equal(500);
-        expect(response.text).to.equal(
-          '{"errors":[{"message":"I did something wrong"}]}'
-        );
-      });
+          const response = await request(app)
+            .get(urlString({
+              query: '{test}'
+            }));
+
+          expect(response.status).to.equal(500);
+          expect(response.text).to.equal(
+            '{"errors":[{"message":"I did something wrong"}]}'
+          );
+        });
+      })
     });
 
     describe('POST functionality', () => {
-      it('allows POST with JSON encoding', async () => {
-        const app = server();
+      describe('allows/supports', () => {
+        beforeEach(() => {
+          app.post(urlString(), graphqlHTTP({ schema: TestSchema }));
+        });
 
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
-        }));
+        it('POST with JSON encoding', async () => {
+          const response = await request(app)
+            .post(urlString()).send({ query: '{test}' });
 
-        const response = await request(app)
-          .post(urlString()).send({ query: '{test}' });
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello World"}}'
+          );
+        });
 
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello World"}}'
-        );
-      });
+        it('sending a mutation via POST', async () => {
+          const response = await request(app)
+            .post(urlString())
+            .send({ query: 'mutation TestMutation { writeTest { test } }' });
 
-      it('Allows sending a mutation via POST', async () => {
-        const app = server();
+          expect(response.status).to.equal(200);
+          expect(response.text).to.equal(
+            '{"data":{"writeTest":{"test":"Hello World"}}}'
+          );
+        });
 
-        app.use(urlString(), graphqlHTTP({ schema: TestSchema }));
+        it('POST with url encoding', async () => {
+          const response = await request(app)
+            .post(urlString())
+            .send(stringify({ query: '{test}' }));
 
-        const response = await request(app)
-          .post(urlString())
-          .send({ query: 'mutation TestMutation { writeTest { test } }' });
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello World"}}'
+          );
+        });
 
-        expect(response.status).to.equal(200);
-        expect(response.text).to.equal(
-          '{"data":{"writeTest":{"test":"Hello World"}}}'
-        );
-      });
+        it('POST JSON query with string variables', async () => {
+          const response = await request(app)
+            .post(urlString())
+            .send({
+              query: 'query helloWho($who: String){ test(who: $who) }',
+              variables: JSON.stringify({ who: 'Dolly' })
+            });
 
-      it('allows POST with url encoding', async () => {
-        const app = server();
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello Dolly"}}'
+          );
+        });
 
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
-        }));
+        it('POST JSON query with JSON variables', async () => {
+          const response = await request(app)
+            .post(urlString())
+            .send({
+              query: 'query helloWho($who: String){ test(who: $who) }',
+              variables: { who: 'Dolly' }
+            });
 
-        const response = await request(app)
-          .post(urlString())
-          .send(stringify({ query: '{test}' }));
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello Dolly"}}'
+          );
+        });
 
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello World"}}'
-        );
-      });
+        it('POST url encoded query with string variables', async () => {
+          const response = await request(app)
+            .post(urlString())
+            .send(stringify({
+              query: 'query helloWho($who: String){ test(who: $who) }',
+              variables: JSON.stringify({ who: 'Dolly' })
+            }));
 
-      it('supports POST JSON query with string variables', async () => {
-        const app = server();
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello Dolly"}}'
+          );
+        });
 
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
-        }));
+        it('POST JSON query with GET variable values', async () => {
+          const response = await request(app)
+            .post(urlString({
+              variables: JSON.stringify({ who: 'Dolly' })
+            }))
+            .send({ query: 'query helloWho($who: String){ test(who: $who) }' });
 
-        const response = await request(app)
-          .post(urlString())
-          .send({
-            query: 'query helloWho($who: String){ test(who: $who) }',
-            variables: JSON.stringify({ who: 'Dolly' })
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello Dolly"}}'
+          );
+        });
+
+        it('POST url encoded query with GET variable values', async () => {
+          const response = await request(app)
+            .post(urlString({
+              variables: JSON.stringify({ who: 'Dolly' })
+            }))
+            .send(stringify({
+              query: 'query helloWho($who: String){ test(who: $who) }'
+            }));
+
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello Dolly"}}'
+          );
+        });
+
+        it('POST raw text query with GET variable values', async () => {
+          const response = await request(app)
+            .post(urlString({
+              variables: JSON.stringify({ who: 'Dolly' })
+            }))
+            .set('Content-Type', 'application/graphql')
+            .send('query helloWho($who: String){ test(who: $who) }');
+
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello Dolly"}}'
+          );
+        });
+
+        it('POST with operation name', async () => {
+          const response = await request(app)
+            .post(urlString())
+            .send({
+              query: `
+                query helloYou { test(who: "You"), ...shared }
+                query helloWorld { test(who: "World"), ...shared }
+                query helloDolly { test(who: "Dolly"), ...shared }
+                fragment shared on QueryRoot {
+                  shared: test(who: "Everyone")
+                }
+              `,
+              operationName: 'helloWorld'
+            });
+
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: {
+              test: 'Hello World',
+              shared: 'Hello Everyone',
+            }
           });
+        });
 
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello Dolly"}}'
-        );
-      });
-
-      it('supports POST JSON query with JSON variables', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
-        }));
-
-        const response = await request(app)
-          .post(urlString())
-          .send({
-            query: 'query helloWho($who: String){ test(who: $who) }',
-            variables: { who: 'Dolly' }
-          });
-
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello Dolly"}}'
-        );
-      });
-
-      it('supports POST url encoded query with string variables', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
-        }));
-
-        const response = await request(app)
-          .post(urlString())
-          .send(stringify({
-            query: 'query helloWho($who: String){ test(who: $who) }',
-            variables: JSON.stringify({ who: 'Dolly' })
-          }));
-
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello Dolly"}}'
-        );
-      });
-
-      it('supports POST JSON query with GET variable values', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
-        }));
-
-        const response = await request(app)
-          .post(urlString({
-            variables: JSON.stringify({ who: 'Dolly' })
-          }))
-          .send({ query: 'query helloWho($who: String){ test(who: $who) }' });
-
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello Dolly"}}'
-        );
-      });
-
-      it('supports POST url encoded query with GET variable values', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
-        }));
-
-        const response = await request(app)
-          .post(urlString({
-            variables: JSON.stringify({ who: 'Dolly' })
-          }))
-          .send(stringify({
-            query: 'query helloWho($who: String){ test(who: $who) }'
-          }));
-
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello Dolly"}}'
-        );
-      });
-
-      it('supports POST raw text query with GET variable values', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
-        }));
-
-        const response = await request(app)
-          .post(urlString({
-            variables: JSON.stringify({ who: 'Dolly' })
-          }))
-          .set('Content-Type', 'application/graphql')
-          .send('query helloWho($who: String){ test(who: $who) }');
-
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello Dolly"}}'
-        );
-      });
-
-      it('allows POST with operation name', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP(() => ({
-          schema: TestSchema
-        })));
-
-        const response = await request(app)
-          .post(urlString())
-          .send({
-            query: `
+        it('POST with GET operation name', async () => {
+          const response = await request(app)
+            .post(urlString({
+              operationName: 'helloWorld'
+            }))
+            .set('Content-Type', 'application/graphql')
+            .send(`
               query helloYou { test(who: "You"), ...shared }
               query helloWorld { test(who: "World"), ...shared }
               query helloDolly { test(who: "Dolly"), ...shared }
               fragment shared on QueryRoot {
                 shared: test(who: "Everyone")
               }
-            `,
-            operationName: 'helloWorld'
+            `);
+
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: {
+              test: 'Hello World',
+              shared: 'Hello Everyone',
+            }
+          });
+        });
+
+        it('other UTF charsets', async () => {
+          const req = request(app)
+            .post(urlString())
+            .set('Content-Type', 'application/graphql; charset=utf-16');
+          req.write(new Buffer('{ test(who: "World") }', 'utf16le'));
+          const response = await req;
+
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: {
+              test: 'Hello World'
+            }
+          });
+        });
+
+        it('gzipped POST bodies', async () => {
+          const data = { query: '{ test(who: "World") }' };
+          const json = JSON.stringify(data);
+          const gzippedJson = await promiseTo(cb => zlib.gzip(json, cb));
+
+          const req = request(app)
+            .post(urlString())
+            .set('Content-Type', 'application/json')
+            .set('Content-Encoding', 'gzip');
+          req.write(gzippedJson);
+          const response = await req;
+
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: {
+              test: 'Hello World'
+            }
+          });
+        });
+
+        it('deflated POST bodies', async () => {
+          const data = { query: '{ test(who: "World") }' };
+          const json = JSON.stringify(data);
+          const deflatedJson = await promiseTo(cb => zlib.deflate(json, cb));
+
+          const req = request(app)
+            .post(urlString())
+            .set('Content-Type', 'application/json')
+            .set('Content-Encoding', 'deflate');
+          req.write(deflatedJson);
+          const response = await req;
+
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: {
+              test: 'Hello World'
+            }
+          });
+        });
+      })
+
+      describe('allows for pre-parsed POST', () => {
+        it('bodies', async function () {
+          // TODO: get this test working with restify
+          if (name === 'restify') this.skip();
+
+          // Note: this is not the only way to handle file uploads with GraphQL,
+          // but it is terse and illustrative of using express-graphql and multer
+          // together.
+
+          // A simple schema which includes a mutation.
+          const UploadedFileType = new GraphQLObjectType({
+            name: 'UploadedFile',
+            fields: {
+              originalname: { type: GraphQLString },
+              mimetype: { type: GraphQLString }
+            }
           });
 
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: {
-            test: 'Hello World',
-            shared: 'Hello Everyone',
-          }
-        });
-      });
-
-      it('allows POST with GET operation name', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP(() => ({
-          schema: TestSchema
-        })));
-
-        const response = await request(app)
-          .post(urlString({
-            operationName: 'helloWorld'
-          }))
-          .set('Content-Type', 'application/graphql')
-          .send(`
-            query helloYou { test(who: "You"), ...shared }
-            query helloWorld { test(who: "World"), ...shared }
-            query helloDolly { test(who: "Dolly"), ...shared }
-            fragment shared on QueryRoot {
-              shared: test(who: "Everyone")
-            }
-          `);
-
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: {
-            test: 'Hello World',
-            shared: 'Hello Everyone',
-          }
-        });
-      });
-
-      it('allows other UTF charsets', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP(() => ({
-          schema: TestSchema
-        })));
-
-        const req = request(app)
-          .post(urlString())
-          .set('Content-Type', 'application/graphql; charset=utf-16');
-        req.write(new Buffer('{ test(who: "World") }', 'utf16le'));
-        const response = await req;
-
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: {
-            test: 'Hello World'
-          }
-        });
-      });
-
-      it('allows gzipped POST bodies', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP(() => ({
-          schema: TestSchema
-        })));
-
-        const data = { query: '{ test(who: "World") }' };
-        const json = JSON.stringify(data);
-        const gzippedJson = await promiseTo(cb => zlib.gzip(json, cb));
-
-        const req = request(app)
-          .post(urlString())
-          .set('Content-Type', 'application/json')
-          .set('Content-Encoding', 'gzip');
-        req.write(gzippedJson);
-        const response = await req;
-
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: {
-            test: 'Hello World'
-          }
-        });
-      });
-
-      it('allows deflated POST bodies', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP(() => ({
-          schema: TestSchema
-        })));
-
-        const data = { query: '{ test(who: "World") }' };
-        const json = JSON.stringify(data);
-        const deflatedJson = await promiseTo(cb => zlib.deflate(json, cb));
-
-        const req = request(app)
-          .post(urlString())
-          .set('Content-Type', 'application/json')
-          .set('Content-Encoding', 'deflate');
-        req.write(deflatedJson);
-        const response = await req;
-
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: {
-            test: 'Hello World'
-          }
-        });
-      });
-
-      it('allows for pre-parsed POST bodies', async () => {
-        // Note: this is not the only way to handle file uploads with GraphQL,
-        // but it is terse and illustrative of using express-graphql and multer
-        // together.
-
-        // A simple schema which includes a mutation.
-        const UploadedFileType = new GraphQLObjectType({
-          name: 'UploadedFile',
-          fields: {
-            originalname: { type: GraphQLString },
-            mimetype: { type: GraphQLString }
-          }
-        });
-
-        const TestMutationSchema = new GraphQLSchema({
-          query: new GraphQLObjectType({
-            name: 'QueryRoot',
-            fields: {
-              test: { type: GraphQLString }
-            }
-          }),
-          mutation: new GraphQLObjectType({
-            name: 'MutationRoot',
-            fields: {
-              uploadFile: {
-                type: UploadedFileType,
-                resolve(rootValue) {
-                  // For this test demo, we're just returning the uploaded
-                  // file directly, but presumably you might return a Promise
-                  // to go store the file somewhere first.
-                  return rootValue.request.file;
+          const TestMutationSchema = new GraphQLSchema({
+            query: new GraphQLObjectType({
+              name: 'QueryRoot',
+              fields: {
+                test: { type: GraphQLString }
+              }
+            }),
+            mutation: new GraphQLObjectType({
+              name: 'MutationRoot',
+              fields: {
+                uploadFile: {
+                  type: UploadedFileType,
+                  resolve(rootValue) {
+                    // For this test demo, we're just returning the uploaded
+                    // file directly, but presumably you might return a Promise
+                    // to go store the file somewhere first.
+                    return rootValue.request.file;
+                  }
                 }
               }
+            })
+          });
+
+          // Multer provides multipart form data parsing.
+          const storage = multer.memoryStorage();
+          app.post(urlString(), multer({ storage }).single('file'));
+
+          // Providing the request as part of `rootValue` allows it to
+          // be accessible from within Schema resolve functions.
+          app.post(urlString(), graphqlHTTP(req => {
+            return {
+              schema: TestMutationSchema,
+              rootValue: { request: req }
+            };
+          }));
+
+          const response = await request(app)
+            .post(urlString())
+            .field('query', `mutation TestMutation {
+              uploadFile { originalname, mimetype }
+            }`)
+            .attach('file', __filename);
+
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: {
+              uploadFile: {
+                originalname: 'http-test.js',
+                mimetype: 'application/javascript'
+              }
             }
-          })
+          });
         });
 
-        const app = server();
+        it('using application/graphql', async () => {
+          app.use(bodyParser.text({ type: 'application/graphql' }));
+          app.post(urlString(), graphqlHTTP({ schema: TestSchema }));
 
-        // Multer provides multipart form data parsing.
-        const storage = multer.memoryStorage();
-        app.use(urlString(), multer({ storage }).single('file'));
+          const req = request(app)
+            .post(urlString())
+            .set('Content-Type', 'application/graphql');
+          req.write(new Buffer('{ test(who: "World") }'));
+          const response = await req;
 
-        // Providing the request as part of `rootValue` allows it to
-        // be accessible from within Schema resolve functions.
-        app.use(urlString(), graphqlHTTP(req => {
-          return {
-            schema: TestMutationSchema,
-            rootValue: { request: req }
-          };
-        }));
-
-        const response = await request(app)
-          .post(urlString())
-          .field('query', `mutation TestMutation {
-            uploadFile { originalname, mimetype }
-          }`)
-          .attach('file', __filename);
-
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: {
-            uploadFile: {
-              originalname: 'http-test.js',
-              mimetype: 'application/javascript'
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: {
+              test: 'Hello World'
             }
-          }
+          });
+        });
+      })
+
+      describe('does not accept unknown pre-parsed POST', () => {
+        it('string', async () => {
+          app.use(bodyParser.text({ type: '*/*' }));
+          app.post(urlString(), graphqlHTTP({ schema: TestSchema }));
+
+          const req = request(app)
+            .post(urlString());
+          req.write(new Buffer('{ test(who: "World") }'));
+          const response = await req;
+
+          expect(response.status).to.equal(400);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [ { message: 'Must provide query string.' } ]
+          });
+        });
+
+        it('raw Buffer', async () => {
+          app.use(bodyParser.raw({ type: '*/*' }));
+          app.post(urlString(), graphqlHTTP({ schema: TestSchema }));
+
+          const req = request(app)
+            .post(urlString())
+            .set('Content-Type', 'application/graphql');
+          req.write(new Buffer('{ test(who: "World") }'));
+          const response = await req;
+
+          expect(response.status).to.equal(400);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [ { message: 'Must provide query string.' } ]
+          });
         });
       });
-
-      it('allows for pre-parsed POST using application/graphql', async () => {
-        const app = server();
-        app.use(bodyParser.text({ type: 'application/graphql' }));
-
-        app.use(urlString(), graphqlHTTP({ schema: TestSchema }));
-
-        const req = request(app)
-          .post(urlString())
-          .set('Content-Type', 'application/graphql');
-        req.write(new Buffer('{ test(who: "World") }'));
-        const response = await req;
-
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: {
-            test: 'Hello World'
-          }
-        });
-      });
-
-      it('does not accept unknown pre-parsed POST string', async () => {
-        const app = server();
-        app.use(bodyParser.text({ type: '*/*' }));
-
-        app.use(urlString(), graphqlHTTP({ schema: TestSchema }));
-
-        const req = request(app)
-          .post(urlString());
-        req.write(new Buffer('{ test(who: "World") }'));
-        const response = await req;
-
-        expect(response.status).to.equal(400);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [ { message: 'Must provide query string.' } ]
-        });
-      });
-
-      it('does not accept unknown pre-parsed POST raw Buffer', async () => {
-        const app = server();
-        app.use(bodyParser.raw({ type: '*/*' }));
-
-        app.use(urlString(), graphqlHTTP({ schema: TestSchema }));
-
-        const req = request(app)
-          .post(urlString())
-          .set('Content-Type', 'application/graphql');
-        req.write(new Buffer('{ test(who: "World") }'));
-        const response = await req;
-
-        expect(response.status).to.equal(400);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [ { message: 'Must provide query string.' } ]
-        });
-      });
-    });
+    })
 
     describe('Response functionality', () => {
-      it('uses send only for express', async () => {
-        const app = server();
+      it('uses send for express and restify', async () => {
         let spyEnd = {};
         let spySend = {};
 
         // mount a middleware to spy on response methods
-        app.use(urlString(), (req, res, next) => {
+        app.get(urlString(), graphqlHTTP((req, res) => {
           spyEnd = sinon.spy(res, 'end');
           try {
             // res.send is undefined with connect
@@ -805,34 +700,26 @@ describe('test harness', () => {
           } catch (err) {
             spySend = undefined;
           }
-          next();
-        });
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
+          return { schema: TestSchema };
         }));
 
-        await request(app)
-          .get(urlString({
-            query: '{test}'
-          }));
+        await request(app).get(urlString({ query: '{test}' }));
 
         if (name === 'connect') {
-          expect(spyEnd.calledOnce);
+          expect(spyEnd).to.have.been.called;
           expect(spySend).to.equal(undefined);
         } else {
-          expect(spySend.calledOnce);
+          expect(spySend).to.have.been.called;
+          expect(spyEnd).to.not.have.been.called;
         }
       });
     });
 
     it('will send request and response when using thunk', async () => {
-      const app = server();
-
       let hasRequest = false;
       let hasResponse = false;
 
-      app.use(urlString(), graphqlHTTP((req, res) => {
+      app.get(urlString(), graphqlHTTP((req, res) => {
         if (req) {
           hasRequest = true;
         }
@@ -849,542 +736,426 @@ describe('test harness', () => {
     });
 
     describe('Error handling functionality', () => {
-      it('handles field errors caught by GraphQL', async () => {
-        const app = server();
+      describe('GET handles', () => {
+        beforeEach(() => {
+          app.get(urlString(), graphqlHTTP({
+            schema: TestSchema
+          }));
+        });
 
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
-        }));
+        it('field errors caught by GraphQL', async () => {
+          const response = await request(app)
+            .get(urlString({
+              query: '{thrower}',
+            }));
 
-        const response = await request(app)
-          .get(urlString({
-            query: '{thrower}',
+          expect(response.status).to.equal(200);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { thrower: null },
+            errors: [ {
+              message: 'Throws!',
+              locations: [ { line: 1, column: 2 } ],
+              path: [ 'thrower' ]
+            } ]
+          });
+        });
+
+        it('query errors from non-null top field errors', async () => {
+          const response = await request(app)
+            .get(urlString({
+              query: '{nonNullThrower}',
+            }));
+
+          expect(response.status).to.equal(500);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: null,
+            errors: [ {
+              message: 'Throws!',
+              locations: [ { line: 1, column: 2 } ],
+              path: [ 'nonNullThrower' ]
+            } ]
+          });
+        });
+
+        it('syntax errors caught by GraphQL', async () => {
+          const response = await request(app)
+            .get(urlString({
+              query: 'syntaxerror',
+            }));
+
+          expect(response.status).to.equal(400);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [ {
+              message: 'Syntax Error GraphQL request (1:1) ' +
+                'Unexpected Name "syntaxerror"\n\n1: syntaxerror\n   ^\n',
+              locations: [ { line: 1, column: 1 } ]
+            } ]
+          });
+        });
+
+        it('errors caused by a lack of query', async () => {
+          const response = await request(app).get(urlString());
+
+          expect(response.status).to.equal(400);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [ { message: 'Must provide query string.' } ]
+          });
+        });
+
+        it('poorly formed variables', async () => {
+          const response = await request(app)
+            .get(urlString({
+              variables: 'who:You',
+              query: 'query helloWho($who: String){ test(who: $who) }'
+            }));
+
+          expect(response.status).to.equal(400);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [ { message: 'Variables are invalid JSON.' } ]
+          });
+        });
+      });
+
+      describe('POST handles', () => {
+        beforeEach(() => {
+          app.post(urlString(), graphqlHTTP({
+            schema: TestSchema
+          }));
+        });
+
+        it('invalid JSON bodies', async () => {
+          const response = await request(app)
+            .post(urlString())
+            .set('Content-Type', 'application/json')
+            .send('[]');
+
+          expect(response.status).to.equal(400);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [ { message: 'POST body sent invalid JSON.' } ]
+          });
+        });
+
+        it('incomplete JSON bodies', async () => {
+          const response = await request(app)
+            .post(urlString())
+            .set('Content-Type', 'application/json')
+            .send('{"query":');
+
+          expect(response.status).to.equal(400);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [ { message: 'POST body sent invalid JSON.' } ]
+          });
+        });
+
+        it('plain POST text', async () => {
+          const response = await request(app)
+            .post(urlString({
+              variables: JSON.stringify({ who: 'Dolly' })
+            }))
+            .set('Content-Type', 'text/plain')
+            .send('query helloWho($who: String){ test(who: $who) }');
+
+          expect(response.status).to.equal(400);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [ { message: 'Must provide query string.' } ]
+          });
+        });
+
+        it('unsupported charset', async () => {
+          const response = await request(app)
+            .post(urlString())
+            .set('Content-Type', 'application/graphql; charset=ascii')
+            .send('{ test(who: "World") }');
+
+          expect(response.status).to.equal(415);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [ { message: 'Unsupported charset "ASCII".' } ]
+          });
+        });
+
+        it('unsupported utf charset', async () => {
+          const response = await request(app)
+            .post(urlString())
+            .set('Content-Type', 'application/graphql; charset=utf-53')
+            .send('{ test(who: "World") }');
+
+          expect(response.status).to.equal(415);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [ { message: 'Unsupported charset "UTF-53".' } ]
+          });
+        });
+
+        it('unknown encoding', async () => {
+          const response = await request(app)
+            .post(urlString())
+            .set('Content-Encoding', 'garbage')
+            .send('!@#$%^*(&^$%#@');
+
+          expect(response.status).to.equal(415);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [ { message: 'Unsupported content-encoding "garbage".' } ]
+          });
+        });
+      });
+
+      describe('ALL handles', () => {
+        it('unsupported HTTP methods', async function () {
+          // this test doesn't apply to restify
+          // as you need to define methods manually
+          // for each endpoint
+          if (name === 'restify') this.skip();
+
+          app.use(urlString(), graphqlHTTP({
+            schema: TestSchema
           }));
 
-        expect(response.status).to.equal(200);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: { thrower: null },
-          errors: [ {
-            message: 'Throws!',
-            locations: [ { line: 1, column: 2 } ],
-            path: [ 'thrower' ]
-          } ]
+          const response = await request(app)
+            .put(urlString({ query: '{test}' }));
+
+          expect(response.status).to.equal(405);
+          expect(response.headers.allow).to.equal('GET, POST');
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [
+              { message: 'GraphQL only supports GET and POST requests.' }
+            ]
+          });
         });
       });
 
-      it('handles query errors from non-null top field errors', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
-        }));
-
-        const response = await request(app)
-          .get(urlString({
-            query: '{nonNullThrower}',
+      describe('allows for custom error formatting', () => {
+        it('to sanitize', async () => {
+          app.get(urlString(), graphqlHTTP({
+            schema: TestSchema,
+            formatError(error) {
+              return { message: 'Custom error format: ' + error.message };
+            }
           }));
 
-        expect(response.status).to.equal(500);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: null,
-          errors: [ {
-            message: 'Throws!',
-            locations: [ { line: 1, column: 2 } ],
-            path: [ 'nonNullThrower' ]
-          } ]
+          const response = await request(app)
+            .get(urlString({
+              query: '{thrower}',
+            }));
+
+          expect(response.status).to.equal(200);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { thrower: null },
+            errors: [ {
+              message: 'Custom error format: Throws!',
+            } ]
+          });
         });
-      });
 
-      it('allows for custom error formatting to sanitize', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          formatError(error) {
-            return { message: 'Custom error format: ' + error.message };
-          }
-        }));
-
-        const response = await request(app)
-          .get(urlString({
-            query: '{thrower}',
+        it('to elaborate', async () => {
+          app.get(urlString(), graphqlHTTP({
+            schema: TestSchema,
+            formatError(error) {
+              return {
+                message: error.message,
+                locations: error.locations,
+                stack: 'Stack trace'
+              };
+            }
           }));
 
-        expect(response.status).to.equal(200);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: { thrower: null },
-          errors: [ {
-            message: 'Custom error format: Throws!',
-          } ]
+          const response = await request(app)
+            .get(urlString({
+              query: '{thrower}',
+            }));
+
+          expect(response.status).to.equal(200);
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { thrower: null },
+            errors: [ {
+              message: 'Throws!',
+              locations: [ { line: 1, column: 2 } ],
+              stack: 'Stack trace',
+            } ]
+          });
         });
       });
-
-      it('allows for custom error formatting to elaborate', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          formatError(error) {
-            return {
-              message: error.message,
-              locations: error.locations,
-              stack: 'Stack trace'
-            };
-          }
-        }));
-
-        const response = await request(app)
-          .get(urlString({
-            query: '{thrower}',
-          }));
-
-        expect(response.status).to.equal(200);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          data: { thrower: null },
-          errors: [ {
-            message: 'Throws!',
-            locations: [ { line: 1, column: 2 } ],
-            stack: 'Stack trace',
-          } ]
-        });
-      });
-
-      it('handles syntax errors caught by GraphQL', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-        }));
-
-        const response = await request(app)
-          .get(urlString({
-            query: 'syntaxerror',
-          }));
-
-        expect(response.status).to.equal(400);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [ {
-            message: 'Syntax Error GraphQL request (1:1) ' +
-              'Unexpected Name "syntaxerror"\n\n1: syntaxerror\n   ^\n',
-            locations: [ { line: 1, column: 1 } ]
-          } ]
-        });
-      });
-
-      it('handles errors caused by a lack of query', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-        }));
-
-        const response = await request(app).get(urlString());
-
-        expect(response.status).to.equal(400);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [ { message: 'Must provide query string.' } ]
-        });
-      });
-
-      it('handles invalid JSON bodies', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-        }));
-
-        const response = await request(app)
-          .post(urlString())
-          .set('Content-Type', 'application/json')
-          .send('[]');
-
-        expect(response.status).to.equal(400);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [ { message: 'POST body sent invalid JSON.' } ]
-        });
-      });
-
-      it('handles incomplete JSON bodies', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-        }));
-
-        const response = await request(app)
-          .post(urlString())
-          .set('Content-Type', 'application/json')
-          .send('{"query":');
-
-        expect(response.status).to.equal(400);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [ { message: 'POST body sent invalid JSON.' } ]
-        });
-      });
-
-      it('handles plain POST text', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema
-        }));
-
-        const response = await request(app)
-          .post(urlString({
-            variables: JSON.stringify({ who: 'Dolly' })
-          }))
-          .set('Content-Type', 'text/plain')
-          .send('query helloWho($who: String){ test(who: $who) }');
-
-        expect(response.status).to.equal(400);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [ { message: 'Must provide query string.' } ]
-        });
-      });
-
-      it('handles unsupported charset', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP(() => ({
-          schema: TestSchema
-        })));
-
-        const response = await request(app)
-          .post(urlString())
-          .set('Content-Type', 'application/graphql; charset=ascii')
-          .send('{ test(who: "World") }');
-
-        expect(response.status).to.equal(415);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [ { message: 'Unsupported charset "ASCII".' } ]
-        });
-      });
-
-      it('handles unsupported utf charset', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP(() => ({
-          schema: TestSchema
-        })));
-
-        const response = await request(app)
-          .post(urlString())
-          .set('Content-Type', 'application/graphql; charset=utf-53')
-          .send('{ test(who: "World") }');
-
-        expect(response.status).to.equal(415);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [ { message: 'Unsupported charset "UTF-53".' } ]
-        });
-      });
-
-      it('handles unknown encoding', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP(() => ({
-          schema: TestSchema
-        })));
-
-        const response = await request(app)
-          .post(urlString())
-          .set('Content-Encoding', 'garbage')
-          .send('!@#$%^*(&^$%#@');
-
-        expect(response.status).to.equal(415);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [ { message: 'Unsupported content-encoding "garbage".' } ]
-        });
-      });
-
-      it('handles poorly formed variables', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({ schema: TestSchema }));
-
-        const response = await request(app)
-          .get(urlString({
-            variables: 'who:You',
-            query: 'query helloWho($who: String){ test(who: $who) }'
-          }));
-
-        expect(response.status).to.equal(400);
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [ { message: 'Variables are invalid JSON.' } ]
-        });
-      });
-
-      it('handles unsupported HTTP methods', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({ schema: TestSchema }));
-
-        const response = await request(app)
-          .put(urlString({ query: '{test}' }));
-
-        expect(response.status).to.equal(405);
-        expect(response.headers.allow).to.equal('GET, POST');
-        expect(JSON.parse(response.text)).to.deep.equal({
-          errors: [
-            { message: 'GraphQL only supports GET and POST requests.' }
-          ]
-        });
-      });
-
     });
 
     describe('Built-in GraphiQL support', () => {
-      it('does not renders GraphiQL if no opt-in', async () => {
-        const app = server();
+      describe('no opt-in', () => {
+        it('does not renders GraphiQL if no opt-in', async () => {
+          app.get(urlString(), graphqlHTTP({
+            schema: TestSchema,
+            graphiql: false
+          }));
 
-        app.use(urlString(), graphqlHTTP({ schema: TestSchema }));
+          const response = await request(app)
+            .get(urlString({ query: '{test}' }))
+            .set('Accept', 'text/html');
 
-        const response = await request(app)
-          .get(urlString({ query: '{test}' }))
-          .set('Accept', 'text/html');
-
-        expect(response.status).to.equal(200);
-        expect(response.type).to.equal('application/json');
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello World"}}'
-        );
+          expect(response.status).to.equal(200);
+          expect(response.type).to.equal('application/json');
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello World"}}'
+          );
+        });
       });
 
-      it('presents GraphiQL when accepting HTML', async () => {
-        const app = server();
+      describe('opt-in', () => {
+        beforeEach(() => {
+          app.get(urlString(), graphqlHTTP({
+            schema: TestSchema,
+            graphiql: true
+          }));
+        });
 
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          graphiql: true
-        }));
+        it('presents GraphiQL when accepting HTML', async () => {
+          const response = await request(app)
+            .get(urlString({ query: '{test}' }))
+            .set('Accept', 'text/html');
 
-        const response = await request(app)
-          .get(urlString({ query: '{test}' }))
-          .set('Accept', 'text/html');
+          expect(response.status).to.equal(200);
+          // expect(response.type).to.equal('text/html');
+          expect(response.text).to.include('{test}');
+          expect(response.text).to.include('graphiql.min.js');
+        });
 
-        expect(response.status).to.equal(200);
-        expect(response.type).to.equal('text/html');
-        expect(response.text).to.include('{test}');
-        expect(response.text).to.include('graphiql.min.js');
-      });
+        it('contains a pre-run response within GraphiQL', async () => {
+          const response = await request(app)
+            .get(urlString({ query: '{test}' }))
+            .set('Accept', 'text/html');
 
-      it('contains a pre-run response within GraphiQL', async () => {
-        const app = server();
+          expect(response.status).to.equal(200);
+          expect(response.type).to.equal('text/html');
+          expect(response.text).to.include(
+            'response: ' + JSON.stringify(
+              JSON.stringify({ data: { test: 'Hello World' } }, null, 2)
+            )
+          );
+        });
 
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          graphiql: true
-        }));
+        it('contains a pre-run operation name within GraphiQL', async () => {
+          const response = await request(app)
+            .get(urlString({
+              query: 'query A{a:test} query B{b:test}',
+              operationName: 'B'
+            }))
+            .set('Accept', 'text/html');
 
-        const response = await request(app)
-          .get(urlString({ query: '{test}' }))
-          .set('Accept', 'text/html');
+          expect(response.status).to.equal(200);
+          expect(response.type).to.equal('text/html');
+          expect(response.text).to.include(
+            'response: ' + JSON.stringify(
+              JSON.stringify({ data: { b: 'Hello World' } }, null, 2)
+            )
+          );
+          expect(response.text).to.include('operationName: "B"');
+        });
 
-        expect(response.status).to.equal(200);
-        expect(response.type).to.equal('text/html');
-        expect(response.text).to.include(
-          'response: ' + JSON.stringify(
-            JSON.stringify({ data: { test: 'Hello World' } }, null, 2)
-          )
-        );
-      });
+        it('escapes HTML in queries within GraphiQL', async () => {
+          const response = await request(app)
+            .get(urlString({ query: '</script><script>alert(1)</script>' }))
+            .set('Accept', 'text/html');
 
-      it('contains a pre-run operation name within GraphiQL', async () => {
-        const app = server();
+          expect(response.status).to.equal(400);
+          expect(response.type).to.equal('text/html');
+          expect(response.text).to.not.include('</script><script>alert(1)</script>');
+        });
 
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          graphiql: true
-        }));
-
-        const response = await request(app)
-          .get(urlString({
-            query: 'query A{a:test} query B{b:test}',
-            operationName: 'B'
-          }))
-          .set('Accept', 'text/html');
-
-        expect(response.status).to.equal(200);
-        expect(response.type).to.equal('text/html');
-        expect(response.text).to.include(
-          'response: ' + JSON.stringify(
-            JSON.stringify({ data: { b: 'Hello World' } }, null, 2)
-          )
-        );
-        expect(response.text).to.include('operationName: "B"');
-      });
-
-      it('escapes HTML in queries within GraphiQL', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          graphiql: true
-        }));
-
-        const response = await request(app)
-          .get(urlString({ query: '</script><script>alert(1)</script>' }))
-          .set('Accept', 'text/html');
-
-        expect(response.status).to.equal(400);
-        expect(response.type).to.equal('text/html');
-        expect(response.text).to.not.include('</script><script>alert(1)</script>');
-      });
-
-      it('escapes HTML in variables within GraphiQL', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          graphiql: true
-        }));
-
-        const response = await request(app).get(urlString({
-          query: 'query helloWho($who: String) { test(who: $who) }',
-          variables: JSON.stringify({
-            who: '</script><script>alert(1)</script>'
-          })
-        })) .set('Accept', 'text/html');
-
-        expect(response.status).to.equal(200);
-        expect(response.type).to.equal('text/html');
-        expect(response.text).to.not.include('</script><script>alert(1)</script>');
-      });
-
-      it('GraphiQL renders provided variables', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          graphiql: true
-        }));
-
-        const response = await request(app)
-          .get(urlString({
+        it('escapes HTML in variables within GraphiQL', async () => {
+          const response = await request(app).get(urlString({
             query: 'query helloWho($who: String) { test(who: $who) }',
-            variables: JSON.stringify({ who: 'Dolly' })
-          }))
-          .set('Accept', 'text/html');
+            variables: JSON.stringify({
+              who: '</script><script>alert(1)</script>'
+            })
+          })) .set('Accept', 'text/html');
 
-        expect(response.status).to.equal(200);
-        expect(response.type).to.equal('text/html');
-        expect(response.text).to.include(
-          'variables: ' + JSON.stringify(
-            JSON.stringify({ who: 'Dolly' }, null, 2)
-          )
-        );
-      });
+          expect(response.status).to.equal(200);
+          expect(response.type).to.equal('text/html');
+          expect(response.text).to.not.include('</script><script>alert(1)</script>');
+        });
 
-      it('GraphiQL accepts an empty query', async () => {
-        const app = server();
+        it('GraphiQL renders provided variables', async () => {
+          const response = await request(app)
+            .get(urlString({
+              query: 'query helloWho($who: String) { test(who: $who) }',
+              variables: JSON.stringify({ who: 'Dolly' })
+            }))
+            .set('Accept', 'text/html');
 
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          graphiql: true
-        }));
+          expect(response.status).to.equal(200);
+          expect(response.type).to.equal('text/html');
+          expect(response.text).to.include(
+            'variables: ' + JSON.stringify(
+              JSON.stringify({ who: 'Dolly' }, null, 2)
+            )
+          );
+        });
 
-        const response = await request(app)
-          .get(urlString())
-          .set('Accept', 'text/html');
+        it('GraphiQL accepts an empty query', async () => {
+          const response = await request(app)
+            .get(urlString())
+            .set('Accept', 'text/html');
 
-        expect(response.status).to.equal(200);
-        expect(response.type).to.equal('text/html');
-        expect(response.text).to.include('response: undefined');
-      });
+          expect(response.status).to.equal(200);
+          expect(response.type).to.equal('text/html');
+          expect(response.text).to.include('response: undefined');
+        });
 
-      it('GraphiQL accepts a mutation query - does not execute it', async () => {
-        const app = server();
+        it('GraphiQL accepts a mutation query - does not execute it', async () => {
+          const response = await request(app)
+            .get(urlString({
+              query: 'mutation TestMutation { writeTest { test } }'
+            }))
+            .set('Accept', 'text/html');
 
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          graphiql: true
-        }));
+          expect(response.status).to.equal(200);
+          expect(response.type).to.equal('text/html');
+          expect(response.text).to.include(
+            'query: "mutation TestMutation { writeTest { test } }"'
+          );
+          expect(response.text).to.include('response: undefined');
+        });
 
-        const response = await request(app)
-          .get(urlString({
-            query: 'mutation TestMutation { writeTest { test } }'
-          }))
-          .set('Accept', 'text/html');
+        it('returns HTML if preferred', async () => {
+          const response = await request(app)
+            .get(urlString({ query: '{test}' }))
+            .set('Accept', 'text/html,application/json');
 
-        expect(response.status).to.equal(200);
-        expect(response.type).to.equal('text/html');
-        expect(response.text).to.include(
-          'query: "mutation TestMutation { writeTest { test } }"'
-        );
-        expect(response.text).to.include('response: undefined');
-      });
+          expect(response.status).to.equal(200);
+          expect(response.type).to.equal('text/html');
+          expect(response.text).to.include('graphiql.min.js');
+        });
 
-      it('returns HTML if preferred', async () => {
-        const app = server();
+        it('returns JSON if preferred', async () => {
+          const response = await request(app)
+            .get(urlString({ query: '{test}' }))
+            .set('Accept', 'application/json,text/html');
 
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          graphiql: true
-        }));
+          expect(response.status).to.equal(200);
+          expect(response.type).to.equal('application/json');
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello World"}}'
+          );
+        });
 
-        const response = await request(app)
-          .get(urlString({ query: '{test}' }))
-          .set('Accept', 'text/html,application/json');
+        it('prefers JSON if unknown accept', async () => {
+          const response = await request(app)
+            .get(urlString({ query: '{test}' }))
+            .set('Accept', 'unknown');
 
-        expect(response.status).to.equal(200);
-        expect(response.type).to.equal('text/html');
-        expect(response.text).to.include('graphiql.min.js');
-      });
+          expect(response.status).to.equal(200);
+          expect(response.type).to.equal('application/json');
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello World"}}'
+          );
+        });
 
-      it('returns JSON if preferred', async () => {
-        const app = server();
+        it('prefers JSON if explicitly requested raw response', async () => {
+          const response = await request(app)
+            .get(urlString({ query: '{test}', raw: '' }))
+            .set('Accept', 'text/html');
 
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          graphiql: true
-        }));
-
-        const response = await request(app)
-          .get(urlString({ query: '{test}' }))
-          .set('Accept', 'application/json,text/html');
-
-        expect(response.status).to.equal(200);
-        expect(response.type).to.equal('application/json');
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello World"}}'
-        );
-      });
-
-      it('prefers JSON if unknown accept', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          graphiql: true
-        }));
-
-        const response = await request(app)
-          .get(urlString({ query: '{test}' }))
-          .set('Accept', 'unknown');
-
-        expect(response.status).to.equal(200);
-        expect(response.type).to.equal('application/json');
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello World"}}'
-        );
-      });
-
-      it('prefers JSON if explicitly requested raw response', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
-          schema: TestSchema,
-          graphiql: true
-        }));
-
-        const response = await request(app)
-          .get(urlString({ query: '{test}', raw: '' }))
-          .set('Accept', 'text/html');
-
-        expect(response.status).to.equal(200);
-        expect(response.type).to.equal('application/json');
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello World"}}'
-        );
+          expect(response.status).to.equal(200);
+          expect(response.type).to.equal('application/json');
+          expect(response.text).to.equal(
+            '{"data":{"test":"Hello World"}}'
+          );
+        });
       });
     });
 
@@ -1401,9 +1172,7 @@ describe('test harness', () => {
       };
 
       it('Do not execute a query if it do not pass the custom validation.', async() => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
+        app.get(urlString(), graphqlHTTP({
           schema: TestSchema,
           validationRules: [ AlwaysInvalidRule ],
           pretty: true,
@@ -1427,11 +1196,8 @@ describe('test harness', () => {
     });
 
     describe('Custom result extensions', () => {
-
       it('allows for adding extensions', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP(() => {
+        app.get(urlString(), graphqlHTTP(() => {
           const startTime = 1000000000; /* Date.now(); */
           return {
             schema: TestSchema,
@@ -1453,9 +1219,7 @@ describe('test harness', () => {
       });
 
       it('extensions have access to initial GraphQL result', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
+        app.get(urlString(), graphqlHTTP({
           schema: TestSchema,
           formatError: () => null,
           extensions({ result }) {
@@ -1483,9 +1247,7 @@ describe('test harness', () => {
       });
 
       it('extension function may be async', async () => {
-        const app = server();
-
-        app.use(urlString(), graphqlHTTP({
+        app.get(urlString(), graphqlHTTP({
           schema: TestSchema,
           async extensions() {
             // Note: you can await arbitrary things here!

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -22,7 +22,8 @@ import multer from 'multer';
 import bodyParser from 'body-parser';
 import request from 'supertest-as-promised';
 import connect from 'connect';
-import express4 from 'express';
+import express3 from 'express3'; // deprecated but commonly still used
+import express4 from 'express'; // current
 import restify4 from 'restify';
 import {
   GraphQLSchema,
@@ -118,7 +119,8 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
 
 ([
   [ connect, 'connect' ],
-  [ express4, 'express' ],
+  [ express3, 'express-legacy' ],
+  [ express4, 'express-current' ],
   [ restify4, 'restify' ]
 ])
 .forEach(([ server, name ]) => {
@@ -144,9 +146,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
               query: '{test}'
             }));
 
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello World"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello World' }
+          });
         });
 
         it('allows GET with variable values', async () => {
@@ -156,9 +158,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
               variables: JSON.stringify({ who: 'Dolly' })
             }));
 
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello Dolly"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello Dolly' }
+          });
         });
 
         it('allows GET with operation name', async () => {
@@ -346,9 +348,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
               query: '{test}'
             }));
 
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello World"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello World' }
+          });
         });
 
         it('Catches errors thrown from options function', async () => {
@@ -367,9 +369,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
             }));
 
           expect(response.status).to.equal(500);
-          expect(response.text).to.equal(
-            '{"errors":[{"message":"I did something wrong"}]}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            errors: [ { message: 'I did something wrong' } ]
+          });
         });
       });
     });
@@ -388,9 +390,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
           const response = await request(app)
             .post(urlString()).send({ query: '{test}' });
 
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello World"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello World' }
+          });
         });
 
         it('sending a mutation via POST', async () => {
@@ -399,9 +401,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
             .send({ query: 'mutation TestMutation { writeTest { test } }' });
 
           expect(response.status).to.equal(200);
-          expect(response.text).to.equal(
-            '{"data":{"writeTest":{"test":"Hello World"}}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { writeTest: { test: 'Hello World' } }
+          });
         });
 
         it('POST with url encoding', async () => {
@@ -409,9 +411,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
             .post(urlString())
             .send(stringify({ query: '{test}' }));
 
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello World"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello World' }
+          });
         });
 
         it('POST JSON query with string variables', async () => {
@@ -422,9 +424,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
               variables: JSON.stringify({ who: 'Dolly' })
             });
 
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello Dolly"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello Dolly' }
+          });
         });
 
         it('POST JSON query with JSON variables', async () => {
@@ -435,9 +437,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
               variables: { who: 'Dolly' }
             });
 
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello Dolly"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello Dolly' }
+          });
         });
 
         it('POST url encoded query with string variables', async () => {
@@ -448,9 +450,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
               variables: JSON.stringify({ who: 'Dolly' })
             }));
 
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello Dolly"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello Dolly' }
+          });
         });
 
         it('POST JSON query with GET variable values', async () => {
@@ -460,9 +462,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
             }))
             .send({ query: 'query helloWho($who: String){ test(who: $who) }' });
 
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello Dolly"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello Dolly' }
+          });
         });
 
         it('POST url encoded query with GET variable values', async () => {
@@ -474,9 +476,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
               query: 'query helloWho($who: String){ test(who: $who) }'
             }));
 
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello Dolly"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello Dolly' }
+          });
         });
 
         it('POST raw text query with GET variable values', async () => {
@@ -487,9 +489,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
             .set('Content-Type', 'application/graphql')
             .send('query helloWho($who: String){ test(who: $who) }');
 
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello Dolly"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello Dolly' }
+          });
         });
 
         it('POST with operation name', async () => {
@@ -1063,9 +1065,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
 
           expect(response.status).to.equal(200);
           expect(response.type).to.equal('application/json');
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello World"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello World' }
+          });
         });
       });
 
@@ -1207,9 +1209,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
 
           expect(response.status).to.equal(200);
           expect(response.type).to.equal('application/json');
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello World"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello World' }
+          });
         });
 
         it('prefers JSON if unknown accept', async () => {
@@ -1219,9 +1221,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
 
           expect(response.status).to.equal(200);
           expect(response.type).to.equal('application/json');
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello World"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello World' }
+          });
         });
 
         it('prefers JSON if explicitly requested raw response', async () => {
@@ -1231,9 +1233,9 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
 
           expect(response.status).to.equal(200);
           expect(response.type).to.equal('application/json');
-          expect(response.text).to.equal(
-            '{"data":{"test":"Hello World"}}'
-          );
+          expect(JSON.parse(response.text)).to.deep.equal({
+            data: { test: 'Hello World' }
+          });
         });
       });
     });
@@ -1302,9 +1304,10 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
 
         expect(response.status).to.equal(200);
         expect(response.type).to.equal('application/json');
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello World"},"extensions":{"runTime":10}}'
-        );
+        expect(JSON.parse(response.text)).to.deep.equal({
+          data: { test: 'Hello World' },
+          extensions: { runTime: 10 }
+        });
       });
 
       it('extensions have access to initial GraphQL result', async () => {
@@ -1360,9 +1363,10 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
 
         expect(response.status).to.equal(200);
         expect(response.type).to.equal('application/json');
-        expect(response.text).to.equal(
-          '{"data":{"test":"Hello World"},"extensions":{"eventually":42}}'
-        );
+        expect(JSON.parse(response.text)).to.deep.equal({
+          data: { test: 'Hello World' },
+          extensions: { eventually: 42 }
+        });
       });
     });
   });

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -93,7 +93,6 @@ function promiseTo(fn) {
 }
 
 describe('test harness', () => {
-
   it('resolves callback promises', async () => {
     const resolveValue = {};
     const result = await promiseTo(cb => cb(null, resolveValue));
@@ -113,7 +112,7 @@ describe('test harness', () => {
 
 });
 
-const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
+const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
 
 ([
   [ connect, 'connect' ],
@@ -130,8 +129,11 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
     describe('GET functionality', () => {
       describe('Without context', () => {
         beforeEach(() => {
-          if (name === 'restify') app.get(...basicConfig);
-          else app.use(...basicConfig);
+          if (name === 'restify') {
+            app.get(...basicConfig);
+          } else {
+            app.use(...basicConfig);
+          }
         });
 
         it('allows GET with query param', async () => {
@@ -266,16 +268,19 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
             }
           });
         });
-      })
+      });
 
       describe('With context', () => {
         it('Allows passing in a context', async () => {
-          const config = [urlString(), graphqlHTTP({
+          const config = [ urlString(), graphqlHTTP({
             schema: TestSchema,
             context: 'testValue'
-          })]
-          if (name === 'restify') app.get(...config);
-          else app.use(...config);
+          }) ];
+          if (name === 'restify') {
+            app.get(...config);
+          } else {
+            app.use(...config);
+          }
 
           const response = await request(app)
             .get(urlString({
@@ -300,8 +305,11 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
             next();
           });
 
-          if (name === 'restify') app.get(...basicConfig);
-          else app.use(...basicConfig);
+          if (name === 'restify') {
+            app.get(...basicConfig);
+          } else {
+            app.use(...basicConfig);
+          }
 
           const response = await request(app)
             .get(urlString({
@@ -318,15 +326,18 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
             }
           });
         });
-      })
+      });
 
       describe('With options', () => {
         it('Allows returning an options Promise', async () => {
-          const config = [urlString(), graphqlHTTP(() => Promise.resolve({
+          const config = [ urlString(), graphqlHTTP(() => Promise.resolve({
             schema: TestSchema,
-          }))]
-          if (name === 'restify') app.get(...config);
-          else app.use(...config);
+          })) ];
+          if (name === 'restify') {
+            app.get(...config);
+          } else {
+            app.use(...config);
+          }
 
           const response = await request(app)
             .get(urlString({
@@ -339,11 +350,14 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
         });
 
         it('Catches errors thrown from options function', async () => {
-          const config = [urlString(), graphqlHTTP(() => {
+          const config = [ urlString(), graphqlHTTP(() => {
             throw new Error('I did something wrong');
-          })]
-          if (name === 'restify') app.get(...config);
-          else app.use(...config);
+          }) ];
+          if (name === 'restify') {
+            app.get(...config);
+          } else {
+            app.use(...config);
+          }
 
           const response = await request(app)
             .get(urlString({
@@ -355,14 +369,17 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
             '{"errors":[{"message":"I did something wrong"}]}'
           );
         });
-      })
+      });
     });
 
     describe('POST functionality', () => {
       describe('allows/supports', () => {
         beforeEach(() => {
-          if (name === 'restify') app.post(...basicConfig);
-          else app.use(...basicConfig);
+          if (name === 'restify') {
+            app.post(...basicConfig);
+          } else {
+            app.use(...basicConfig);
+          }
         });
 
         it('POST with JSON encoding', async () => {
@@ -570,12 +587,14 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
             }
           });
         });
-      })
+      });
 
       describe('allows for pre-parsed POST', () => {
         it('bodies', async function () {
           // TODO: get this test working with restify
-          if (name === 'restify') this.skip();
+          if (name === 'restify') {
+            this.skip();
+          }
 
           // Note: this is not the only way to handle file uploads with GraphQL,
           // but it is terse and illustrative of using express-graphql and multer
@@ -646,8 +665,11 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
         it('using application/graphql', async () => {
           app.use(bodyParser.text({ type: 'application/graphql' }));
 
-          if (name === 'restify') app.post(...basicConfig);
-          else app.use(...basicConfig);
+          if (name === 'restify') {
+            app.post(...basicConfig);
+          } else {
+            app.use(...basicConfig);
+          }
 
           const req = request(app)
             .post(urlString())
@@ -661,14 +683,17 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
             }
           });
         });
-      })
+      });
 
       describe('does not accept unknown pre-parsed POST', () => {
         it('string', async () => {
           app.use(bodyParser.text({ type: '*/*' }));
 
-          if (name === 'restify') app.post(...basicConfig);
-          else app.use(...basicConfig);
+          if (name === 'restify') {
+            app.post(...basicConfig);
+          } else {
+            app.use(...basicConfig);
+          }
 
           const req = request(app)
             .post(urlString());
@@ -684,8 +709,11 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
         it('raw Buffer', async () => {
           app.use(bodyParser.raw({ type: '*/*' }));
 
-          if (name === 'restify') app.post(...basicConfig);
-          else app.use(...basicConfig);
+          if (name === 'restify') {
+            app.post(...basicConfig);
+          } else {
+            app.use(...basicConfig);
+          }
 
           const req = request(app)
             .post(urlString())
@@ -699,7 +727,7 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
           });
         });
       });
-    })
+    });
 
     describe('Response functionality', () => {
       it('uses send for express and restify', async () => {
@@ -707,7 +735,7 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
         let spySend = {};
 
         // mount a middleware to spy on response methods
-        const config = [urlString(), graphqlHTTP((req, res) => {
+        const config = [ urlString(), graphqlHTTP((req, res) => {
           spyEnd = sinon.spy(res, 'end');
           try {
             // res.send is undefined with connect
@@ -716,18 +744,21 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
             spySend = undefined;
           }
           return { schema: TestSchema };
-        })]
-        if (name === 'restify') app.get(...config);
-        else app.use(...config);
+        }) ];
+        if (name === 'restify') {
+          app.get(...config);
+        } else {
+          app.use(...config);
+        }
 
         await request(app).get(urlString({ query: '{test}' }));
 
         if (name === 'connect') {
-          expect(spyEnd).to.have.been.called;
+          expect(spyEnd).to.have.been.called; // eslint-disable-line
           expect(spySend).to.equal(undefined);
         } else {
-          expect(spySend).to.have.been.called;
-          expect(spyEnd).to.not.have.been.called;
+          expect(spySend).to.have.been.called; // eslint-disable-line
+          expect(spyEnd).to.not.have.been.called; // eslint-disable-line
         }
       });
     });
@@ -736,7 +767,7 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
       let hasRequest = false;
       let hasResponse = false;
 
-      const config = [urlString(), graphqlHTTP((req, res) => {
+      const config = [ urlString(), graphqlHTTP((req, res) => {
         if (req) {
           hasRequest = true;
         }
@@ -744,9 +775,12 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
           hasResponse = true;
         }
         return { schema: TestSchema };
-      })]
-      if (name === 'restify') app.get(...config);
-      else app.use(...config);
+      }) ];
+      if (name === 'restify') {
+        app.get(...config);
+      } else {
+        app.use(...config);
+      }
 
       await request(app).get(urlString({ query: '{test}' }));
 
@@ -757,8 +791,11 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
     describe('Error handling functionality', () => {
       describe('GET handles', () => {
         beforeEach(() => {
-          if (name === 'restify') app.get(...basicConfig);
-          else app.use(...basicConfig);
+          if (name === 'restify') {
+            app.get(...basicConfig);
+          } else {
+            app.use(...basicConfig);
+          }
         });
 
         it('field errors caught by GraphQL', async () => {
@@ -836,8 +873,11 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
 
       describe('POST handles', () => {
         beforeEach(() => {
-          if (name === 'restify') app.post(...basicConfig);
-          else app.use(...basicConfig);
+          if (name === 'restify') {
+            app.post(...basicConfig);
+          } else {
+            app.use(...basicConfig);
+          }
         });
 
         it('invalid JSON bodies', async () => {
@@ -920,7 +960,9 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
           // this test doesn't apply to restify
           // as you need to define methods manually
           // for each endpoint
-          if (name === 'restify') this.skip();
+          if (name === 'restify') {
+            this.skip();
+          }
 
           app.use(urlString(), graphqlHTTP({
             schema: TestSchema
@@ -941,14 +983,17 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
 
       describe('allows for custom error formatting', () => {
         it('to sanitize', async () => {
-          const config = [urlString(), graphqlHTTP({
+          const config = [ urlString(), graphqlHTTP({
             schema: TestSchema,
             formatError(error) {
               return { message: 'Custom error format: ' + error.message };
             }
-          })]
-          if (name === 'restify') app.get(...config);
-          else app.use(...config);
+          }) ];
+          if (name === 'restify') {
+            app.get(...config);
+          } else {
+            app.use(...config);
+          }
 
           const response = await request(app)
             .get(urlString({
@@ -965,7 +1010,7 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
         });
 
         it('to elaborate', async () => {
-          const config = [urlString(), graphqlHTTP({
+          const config = [ urlString(), graphqlHTTP({
             schema: TestSchema,
             formatError(error) {
               return {
@@ -974,9 +1019,12 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
                 stack: 'Stack trace'
               };
             }
-          })]
-          if (name === 'restify') app.get(...config);
-          else app.use(...config);
+          }) ];
+          if (name === 'restify') {
+            app.get(...config);
+          } else {
+            app.use(...config);
+          }
 
           const response = await request(app)
             .get(urlString({
@@ -999,12 +1047,15 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
     describe('Built-in GraphiQL support', () => {
       describe('no opt-in', () => {
         it('does not renders GraphiQL if no opt-in', async () => {
-          const config = [urlString(), graphqlHTTP({
+          const config = [ urlString(), graphqlHTTP({
             schema: TestSchema,
             graphiql: false
-          })]
-          if (name === 'restify') app.get(...config);
-          else app.use(...config);
+          }) ];
+          if (name === 'restify') {
+            app.get(...config);
+          } else {
+            app.use(...config);
+          }
 
           const response = await request(app)
             .get(urlString({ query: '{test}' }))
@@ -1020,12 +1071,15 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
 
       describe('opt-in', () => {
         beforeEach(() => {
-          const config = [urlString(), graphqlHTTP({
+          const config = [ urlString(), graphqlHTTP({
             schema: TestSchema,
             graphiql: true
-          })]
-          if (name === 'restify') app.get(...config);
-          else app.use(...config);
+          }) ];
+          if (name === 'restify') {
+            app.get(...config);
+          } else {
+            app.use(...config);
+          }
         });
 
         it('presents GraphiQL when accepting HTML', async () => {
@@ -1197,13 +1251,16 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
       };
 
       it('Do not execute a query if it do not pass the custom validation.', async() => {
-        const config = [urlString(), graphqlHTTP({
+        const config = [ urlString(), graphqlHTTP({
           schema: TestSchema,
           validationRules: [ AlwaysInvalidRule ],
           pretty: true,
-        })]
-        if (name === 'restify') app.get(...config);
-        else app.use(...config);
+        }) ];
+        if (name === 'restify') {
+          app.get(...config);
+        } else {
+          app.use(...config);
+        }
 
         const response = await request(app)
           .get(urlString({
@@ -1224,7 +1281,7 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
 
     describe('Custom result extensions', () => {
       it('allows for adding extensions', async () => {
-        const config = [urlString(), graphqlHTTP(() => {
+        const config = [ urlString(), graphqlHTTP(() => {
           const startTime = 1000000000; /* Date.now(); */
           return {
             schema: TestSchema,
@@ -1232,9 +1289,12 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
               return { runTime: 1000000010 /* Date.now() */ - startTime };
             }
           };
-        })]
-        if (name === 'restify') app.get(...config);
-        else app.use(...config);
+        }) ];
+        if (name === 'restify') {
+          app.get(...config);
+        } else {
+          app.use(...config);
+        }
 
         const response = await request(app)
           .get(urlString({ query: '{test}', raw: '' }))
@@ -1248,15 +1308,18 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
       });
 
       it('extensions have access to initial GraphQL result', async () => {
-        const config = [urlString(), graphqlHTTP({
+        const config = [ urlString(), graphqlHTTP({
           schema: TestSchema,
           formatError: () => null,
           extensions({ result }) {
             return { preservedErrors: (result: any).errors };
           }
-        })]
-        if (name === 'restify') app.get(...config);
-        else app.use(...config);
+        }) ];
+        if (name === 'restify') {
+          app.get(...config);
+        } else {
+          app.use(...config);
+        }
 
         const response = await request(app)
           .get(urlString({
@@ -1278,15 +1341,18 @@ const basicConfig = [urlString(), graphqlHTTP({ schema: TestSchema })];
       });
 
       it('extension function may be async', async () => {
-        const config = [urlString(), graphqlHTTP({
+        const config = [ urlString(), graphqlHTTP({
           schema: TestSchema,
           async extensions() {
             // Note: you can await arbitrary things here!
             return { eventually: 42 };
           }
-        })]
-        if (name === 'restify') app.get(...config);
-        else app.use(...config);
+        }) ];
+        if (name === 'restify') {
+          app.get(...config);
+        } else {
+          app.use(...config);
+        }
 
         const response = await request(app)
           .get(urlString({ query: '{test}', raw: '' }))

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -9,7 +9,9 @@
  */
 
 // 80+ char lines are useful in describe/it, so ignore in this file.
+// Also ignore no-unused-expressions rule as chai 'expect' sintax violates it.
 /* eslint-disable max-len */
+/* eslint-disable no-unused-expressions */
 
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
@@ -591,7 +593,7 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
 
       describe('allows for pre-parsed POST', () => {
         it('bodies', async function () {
-          // TODO: get this test working with restify
+          // TODO: can we get this test working with restify?
           if (name === 'restify') {
             this.skip();
           }
@@ -754,11 +756,11 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
         await request(app).get(urlString({ query: '{test}' }));
 
         if (name === 'connect') {
-          expect(spyEnd).to.have.been.called; // eslint-disable-line
+          expect(spyEnd).to.have.been.called;
           expect(spySend).to.equal(undefined);
         } else {
-          expect(spySend).to.have.been.called; // eslint-disable-line
-          expect(spyEnd).to.not.have.been.called; // eslint-disable-line
+          expect(spySend).to.have.been.called;
+          expect(spyEnd).to.not.have.been.called;
         }
       });
     });
@@ -957,9 +959,8 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
 
       describe('ALL handles', () => {
         it('unsupported HTTP methods', async function () {
-          // this test doesn't apply to restify
-          // as you need to define methods manually
-          // for each endpoint
+          // this test doesn't apply to restify because you need
+          // to define methods manually for each endpoint
           if (name === 'restify') {
             this.skip();
           }
@@ -1088,7 +1089,7 @@ const basicConfig = [ urlString(), graphqlHTTP({ schema: TestSchema }) ];
             .set('Accept', 'text/html');
 
           expect(response.status).to.equal(200);
-          // expect(response.type).to.equal('text/html');
+          expect(response.type).to.equal('text/html');
           expect(response.text).to.include('{test}');
           expect(response.text).to.include('graphiql.min.js');
         });

--- a/src/index.js
+++ b/src/index.js
@@ -315,8 +315,9 @@ function graphqlHTTP(options: Options): Middleware {
         response.end(payload);
       } else {
         // Server will stringify our response object, we can return it directly
+        const payload = result || '';
         response.setHeader('Content-Type', 'application/json; charset=utf-8');
-        sendResponse(response, result);
+        sendResponse(response, payload);
       }
     });
   };
@@ -391,8 +392,10 @@ function canDisplayGraphiQL(
 }
 
 /**
- * Helper function for sending the response data. Use response.send it method
- * exists (express), otherwise use response.end (connect).
+ * Helper function for sending the response data. Use response.send if method
+ * exists and response is a string (express, restify); use response.json if
+ * method exist and response is an object to be stringified by the server
+ * (express, restify); otherwise use response.end (connect).
  */
 function sendResponse(
   response: $Response,

--- a/src/index.js
+++ b/src/index.js
@@ -398,11 +398,15 @@ function sendResponse(
   response: $Response,
   data: string | ExecutionResult
 ): void {
+  const dataIsObject = typeof data === 'object'
+
   if (typeof data === 'string' && typeof response.send === 'function') {
-    response.send(data);
-  } else if (typeof data === 'object' && typeof response.json === 'function') {
-    response.json(data);
-  } else {
-    response.end(data);
+    return response.send(data);
   }
+  if (dataIsObject && typeof response.json === 'function') {
+    return response.json(data);
+  }
+
+  const returnData = dataIsObject ? JSON.stringify(data): data
+  response.end(returnData);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -398,7 +398,7 @@ function sendResponse(
   response: $Response,
   data: string | ExecutionResult
 ): void {
-  const dataIsObject = typeof data === 'object'
+  const dataIsObject = typeof data === 'object';
 
   if (typeof data === 'string' && typeof response.send === 'function') {
     return response.send(data);
@@ -407,6 +407,6 @@ function sendResponse(
     return response.json(data);
   }
 
-  const returnData = dataIsObject ? JSON.stringify(data): data
+  const returnData = dataIsObject ? JSON.stringify(data) : data;
   response.end(returnData);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -59,11 +59,6 @@ export type OptionsData = {
   rootValue?: ?mixed,
 
   /**
-   * A boolean to configure whether the output should be pretty-printed.
-   */
-  pretty?: ?boolean,
-
-  /**
    * An optional function which will be used to format any errors produced by
    * fulfilling a GraphQL operation. If no function is provided, GraphQL's
    * default spec-compliant `formatError` function will be used.

--- a/src/index.js
+++ b/src/index.js
@@ -312,7 +312,7 @@ function graphqlHTTP(options: Options): Middleware {
           operationName, result
         });
         response.setHeader('Content-Type', 'text/html; charset=utf-8');
-        sendResponse(response, payload);
+        response.end(payload);
       } else {
         // Server will stringify our response object, we can return it directly
         response.setHeader('Content-Type', 'application/json; charset=utf-8');

--- a/src/index.js
+++ b/src/index.js
@@ -398,12 +398,14 @@ function sendResponse(
   response: $Response,
   data: string | ExecutionResult
 ): void {
+  const dataIsString = typeof data === 'string';
   const dataIsObject = typeof data === 'object';
+  const methodIsFunction = method => typeof method === 'function';
 
-  if (typeof data === 'string' && typeof response.send === 'function') {
+  if (dataIsString && methodIsFunction(response.send)) {
     return response.send(data);
   }
-  if (dataIsObject && typeof response.json === 'function') {
+  if (dataIsObject && methodIsFunction(response.json)) {
     return response.json(data);
   }
 


### PR DESCRIPTION
This PR aims to address issues reported in #216.

## Goal
At the current stage `express-graphql` isn't really usable with restify and I believe that being able to claim full compatibility with it is a great improvement that will help a huge number of developers.

## What does this solve
1. Responses stringified twice
2. GraphiQL support

`express-graphql` is currently stringifying the reponse which is then also stringified by restify before being returned; this is causing the response to be strinfigied twice which would require double parsing on the requesting client application; this also breaks Relay implementation on the client side because Relay tries to parse the response once and expect to deal with an object with `data` and `error` properties.
Changes have been introduced to remove the stringification from `express-graphql` to then send the object response with `res.json()` rather than `res.send()` which is compatible with both `express` and `restify` so that they are explicitly asked to strinfigy the response.

`express-graphql` is responding to a GraphiQL request using `res.send()` which doesn't work with restify. Restify, infact, needs to be provided with a HTML string using `res.end()` in order to be processed as `text/html` type (which also needs to be set in the `Accept` headers when sending the request).
Using `res.end()` when sending `text/html` is still compatible with express as well as `connect`.

## Downside
By delegating the stringification of the response to the server (express/restify) we loose **the 'pretty' option** as we no longer control the stringification directly.
This is not really an issue considering that when using the GraphiQL interface the response is already rendered in a readable and useful state to the user; also many testing tools (like PostMan) have built-in options to pretty print JSON responses.

## Tests
The tests have been refactored to be more efficient and remove duplicated code.
All tests are now also executed against Restify as well.

## Additional notes
The README file has been updated to provide information of how to setup `express-graphql` with restify; also the 'pretty' option has been removed since is no longer supported.