### PR TITLE
Add favicon to prevent invalid GraphQL requests

### DIFF
--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -62,6 +62,7 @@ add "&raw" to the end of the URL within a browser.
     }
   </style>
   <link href="//cdn.jsdelivr.net/graphiql/${GRAPHIQL_VERSION}/graphiql.css" rel="stylesheet" />
+  <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon">
   <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
   <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
   <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>


### PR DESCRIPTION
In my logs, I kept seeing `error: BadRequestError: Must provide query string.` and the request being made was for the favicon. This prevents that request from being made.