### PR TITLE
Add option for body size limit

### DIFF
--- a/src/parseBody.js
+++ b/src/parseBody.js
@@ -20,7 +20,8 @@ import type { Request } from './index';
  * Provided a "Request" provided by express or connect (typically a node style
  * HTTPClientRequest), Promise the body data contained.
  */
-export function parseBody(req: Request): Promise<{[param: string]: mixed}> {
+export function parseBody(req: Request,
+    limit: number): Promise<{[param: string]: mixed}> {
   return new Promise((resolve, reject) => {
     const body = req.body;
 
@@ -50,11 +51,11 @@ export function parseBody(req: Request): Promise<{[param: string]: mixed}> {
     // Use the correct body parser based on Content-Type header.
     switch (typeInfo.type) {
       case 'application/graphql':
-        return read(req, typeInfo, graphqlParser, resolve, reject);
+        return read(req, typeInfo, graphqlParser, resolve, reject, limit);
       case 'application/json':
-        return read(req, typeInfo, jsonEncodedParser, resolve, reject);
+        return read(req, typeInfo, jsonEncodedParser, resolve, reject, limit);
       case 'application/x-www-form-urlencoded':
-        return read(req, typeInfo, urlEncodedParser, resolve, reject);
+        return read(req, typeInfo, urlEncodedParser, resolve, reject, limit);
     }
 
     // If no Content-Type header matches, parse nothing.
@@ -95,7 +96,7 @@ function graphqlParser(body) {
 const jsonObjRegex = /^[\x20\x09\x0a\x0d]*\{/;
 
 // Read and parse a request body.
-function read(req, typeInfo, parseFn, resolve, reject) {
+function read(req, typeInfo, parseFn, resolve, reject, limit) {
   const charset = (typeInfo.parameters.charset || 'utf-8').toLowerCase();
 
   // Assert charset encoding per JSON RFC 7159 sec 8.1
@@ -109,7 +110,6 @@ function read(req, typeInfo, parseFn, resolve, reject) {
     contentEncoding.toLowerCase() :
     'identity';
   const length = encoding === 'identity' ? req.headers['content-length'] : null;
-  const limit = 100 * 1024; // 100kb
   const stream = decompressed(req, encoding);
 
   // Read body from stream.


### PR DESCRIPTION
This change is suggested due to an issue I ran into (client's data is larger than the body limit, in a way that I cannot separate into multiple requests) and that [others](http://stackoverflow.com/questions/41486401/error-request-entity-too-large-in-graphql-services-of-node) have also run into.