### PR TITLE
Use response.json when possible. Safer use of response.end.

### DIFF
--- a/resources/interfaces/express.js
+++ b/resources/interfaces/express.js
@@ -11,4 +11,6 @@ declare class Response {
   status: (code: Number) => Response;
   set: (field: String, value: String) => Response;
   send: (body: String) => void;
+  end: (body: Buffer) => void;
+  json: (body: Object) => void;
 }

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -119,7 +119,18 @@ describe('test harness', () => {
   [ express4, 'express-modern' ],
   [ express3, 'express-old' ]
 ])
-.forEach(([ server, name ]) => {
+.forEach(([ serverImpl, name ]) => {
+
+  function server() {
+    const app = serverImpl();
+    if (app.set) {
+      // This ensures consistent tests, as express defaults json spacing to
+      // 0 only in "production" mode.
+      app.set('json spaces', 0);
+    }
+    return app;
+  }
+
   describe(`GraphQL-HTTP tests for ${name}`, () => {
     describe('GET functionality', () => {
       it('allows GET with query param', async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -302,19 +302,32 @@ function graphqlHTTP(options: Options): Middleware {
       if (result && result.errors) {
         (result: any).errors = result.errors.map(formatErrorFn || formatError);
       }
+
       // If allowed to show GraphiQL, present it instead of JSON.
       if (showGraphiQL) {
         const payload = renderGraphiQL({
-          query, variables,
-          operationName, result
+          query,
+          variables,
+          operationName,
+          result
         });
-        response.setHeader('Content-Type', 'text/html; charset=utf-8');
-        sendResponse(response, payload);
+        return sendResponse(response, 'text/html', payload);
+      }
+
+      // At this point, result is guaranteed to exist, as the only scenario
+      // where it will not is when showGraphiQL is true.
+      if (!result) {
+        throw httpError(500, 'Internal Error');
+      }
+
+      // If "pretty" JSON isn't requested, and the server provides a
+      // response.json method (express), use that directly.
+      // Otherwise use the simplified sendResponse method.
+      if (!pretty && typeof response.json === 'function') {
+        response.json(result);
       } else {
-        // Otherwise, present JSON directly.
         const payload = JSON.stringify(result, null, pretty ? 2 : 0);
-        response.setHeader('Content-Type', 'application/json; charset=utf-8');
-        sendResponse(response, payload);
+        sendResponse(response, 'application/json', payload);
       }
     });
   };
@@ -389,13 +402,11 @@ function canDisplayGraphiQL(
 }
 
 /**
- * Helper function for sending the response data. Use response.send it method
- * exists (express), otherwise use response.end (connect).
+ * Helper function for sending a response using only the core Node server APIs.
  */
-function sendResponse(response: $Response, data: string): void {
-  if (typeof response.send === 'function') {
-    response.send(data);
-  } else {
-    response.end(data);
-  }
+function sendResponse(response: $Response, type: string, data: string): void {
+  const chunk = new Buffer(data, 'utf8');
+  response.setHeader('Content-Type', type + '; charset=utf-8');
+  response.setHeader('Content-Length', String(chunk.length));
+  response.end(chunk);
 }


### PR DESCRIPTION
This fixes a handful of errors that may manifest as a "Socket hangup error" when using the node server API directly without express. It also provides support for the response.json method, which provides more integrated behavior when using a framework which supports it.

Suggested in #272