### PR TITLE
move prettier to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "accepts": "^1.3.0",
     "content-type": "^1.0.2",
     "http-errors": "^1.3.0",
-    "prettier": "^1.3.1",
     "raw-body": "^2.1.0"
   },
   "devDependencies": {
@@ -91,6 +90,7 @@
     "isparta": "4.0.0",
     "mocha": "3.4.2",
     "multer": "1.3.0",
+    "prettier": "^1.3.1",
     "restify": "4.3.0",
     "sane": "1.7.0",
     "sinon": "2.3.1",


### PR DESCRIPTION
I noticed installing the latest version downloaded prettier - i think it's safe to make this a dev dependency.