### PR TITLE
Disable introspection query option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The `graphqlHTTP` function accepts the following options:
   * **`validationRules`**: Optional additional validation rules queries must
     satisfy in addition to those defined by the GraphQL spec.
 
+  * **`introspectionDisabled`**: If `true`, disable schema level introspection queries.
+
 In addition to an object defining each option, options can also be provided as
 a function (or async function) which returns this options object. This function
 is provided the arguments `(request, response, graphQLParams)` and is called

--- a/src/__tests__/disable-introspection-test.js
+++ b/src/__tests__/disable-introspection-test.js
@@ -1,0 +1,38 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { introspectionQuery, parse, validate } from 'graphql';
+import { TestSchema } from './test-schema';
+import { DisableIntrospectionQueries } from '../disable-introspection';
+
+function expectPassesRule(rules, queryString) {
+  const errors = validate(TestSchema, parse(queryString), rules);
+  expect(errors).to.deep.equal([], 'Should validate');
+}
+
+function expectFailsRule(rules, queryString) {
+  const errors = validate(TestSchema, parse(queryString), rules);
+  expect(errors).to.have.length.of.at.least(1, 'Should not validate');
+}
+
+describe('Validate: Query does not contain Introspection', () => {
+  it('valid scalar selection', () => {
+    expectPassesRule(
+      [DisableIntrospectionQueries],
+      `
+      query helloWho($who: String){ test(who: "Steve Buscemi") }
+      `,
+    );
+  });
+  it('invalid introspection', () => {
+    expectFailsRule([DisableIntrospectionQueries], introspectionQuery);
+  });
+});

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -24,65 +24,10 @@ import connect from 'connect';
 import express4 from 'express'; // modern
 import express3 from 'express3'; // old but commonly still used
 import restify from 'restify';
-import {
-  GraphQLSchema,
-  GraphQLObjectType,
-  GraphQLNonNull,
-  GraphQLString,
-  GraphQLError,
-  BREAK,
-} from 'graphql';
+import { GraphQLError, BREAK } from 'graphql';
 import graphqlHTTP from '../';
 
-const QueryRootType = new GraphQLObjectType({
-  name: 'QueryRoot',
-  fields: {
-    test: {
-      type: GraphQLString,
-      args: {
-        who: {
-          type: GraphQLString,
-        },
-      },
-      resolve: (root, { who }) => 'Hello ' + ((who: any) || 'World'),
-    },
-    nonNullThrower: {
-      type: new GraphQLNonNull(GraphQLString),
-      resolve: () => {
-        throw new Error('Throws!');
-      },
-    },
-    thrower: {
-      type: GraphQLString,
-      resolve: () => {
-        throw new Error('Throws!');
-      },
-    },
-    context: {
-      type: GraphQLString,
-      resolve: (obj, args, context) => context,
-    },
-    contextDotFoo: {
-      type: GraphQLString,
-      resolve: (obj, args, context) => {
-        return (context: any).foo;
-      },
-    },
-  },
-});
-
-const TestSchema = new GraphQLSchema({
-  query: QueryRootType,
-  mutation: new GraphQLObjectType({
-    name: 'MutationRoot',
-    fields: {
-      writeTest: {
-        type: QueryRootType,
-        resolve: () => ({}),
-      },
-    },
-  }),
-});
+import { TestMutationSchema, TestSchema } from './test-schema';
 
 function urlString(urlParams?: ?{ [param: string]: mixed }) {
   let string = '/graphql';
@@ -820,39 +765,6 @@ describe('test harness', () => {
         // Note: this is not the only way to handle file uploads with GraphQL,
         // but it is terse and illustrative of using express-graphql and multer
         // together.
-
-        // A simple schema which includes a mutation.
-        const UploadedFileType = new GraphQLObjectType({
-          name: 'UploadedFile',
-          fields: {
-            originalname: { type: GraphQLString },
-            mimetype: { type: GraphQLString },
-          },
-        });
-
-        const TestMutationSchema = new GraphQLSchema({
-          query: new GraphQLObjectType({
-            name: 'QueryRoot',
-            fields: {
-              test: { type: GraphQLString },
-            },
-          }),
-          mutation: new GraphQLObjectType({
-            name: 'MutationRoot',
-            fields: {
-              uploadFile: {
-                type: UploadedFileType,
-                resolve(rootValue) {
-                  // For this test demo, we're just returning the uploaded
-                  // file directly, but presumably you might return a Promise
-                  // to go store the file somewhere first.
-                  return rootValue.request.file;
-                },
-              },
-            },
-          }),
-        });
-
         const app = server();
 
         // Multer provides multipart form data parsing.

--- a/src/__tests__/test-schema.js
+++ b/src/__tests__/test-schema.js
@@ -1,0 +1,106 @@
+/* @flow */
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+// 80+ char lines are useful in describe/it, so ignore in this file.
+/* eslint-disable max-len */
+
+import {
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLNonNull,
+  GraphQLString,
+} from 'graphql';
+
+const QueryRootType = new GraphQLObjectType({
+  name: 'QueryRoot',
+  fields: {
+    test: {
+      type: GraphQLString,
+      args: {
+        who: {
+          type: GraphQLString,
+        },
+      },
+      resolve: (root, { who }) => 'Hello ' + ((who: any) || 'World'),
+    },
+    nonNullThrower: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: () => {
+        throw new Error('Throws!');
+      },
+    },
+    thrower: {
+      type: GraphQLString,
+      resolve: () => {
+        throw new Error('Throws!');
+      },
+    },
+    context: {
+      type: GraphQLString,
+      resolve: (obj, args, context) => context,
+    },
+    contextDotFoo: {
+      type: GraphQLString,
+      resolve: (obj, args, context) => {
+        return (context: any).foo;
+      },
+    },
+  },
+});
+
+const TestSchema = new GraphQLSchema({
+  query: QueryRootType,
+  mutation: new GraphQLObjectType({
+    name: 'MutationRoot',
+    fields: {
+      writeTest: {
+        type: QueryRootType,
+        resolve: () => ({}),
+      },
+    },
+  }),
+});
+
+// A simple schema which includes a mutation.
+const UploadedFileType = new GraphQLObjectType({
+  name: 'UploadedFile',
+  fields: {
+    originalname: { type: GraphQLString },
+    mimetype: { type: GraphQLString },
+  },
+});
+
+const TestMutationSchema = new GraphQLSchema({
+  query: new GraphQLObjectType({
+    name: 'QueryRoot',
+    fields: {
+      test: { type: GraphQLString },
+    },
+  }),
+  mutation: new GraphQLObjectType({
+    name: 'MutationRoot',
+    fields: {
+      uploadFile: {
+        type: UploadedFileType,
+        resolve(rootValue) {
+          // For this test demo, we're just returning the uploaded
+          // file directly, but presumably you might return a Promise
+          // to go store the file somewhere first.
+          return rootValue.request.file;
+        },
+      },
+    },
+  }),
+});
+
+module.exports = {
+  TestMutationSchema,
+  TestSchema,
+};

--- a/src/disable-introspection.js
+++ b/src/disable-introspection.js
@@ -1,0 +1,39 @@
+/* @flow */
+
+import { GraphQLError } from 'graphql';
+
+import type { ValidationContext, GraphQLType, FieldNode } from 'graphql';
+
+const INTROSPECTION_TYPES = ['__Schema!', '__Type!'];
+
+export function noIntrospectionAllowedMessage(
+  fieldName: string,
+  type: GraphQLType,
+): string {
+  return (
+    'Introspection has been disabled for this schema. The field ' +
+    `"${fieldName}" of type "${String(type)}" is not allowed.`
+  );
+}
+
+/**
+ * Disable Introspection Queries
+ *
+ * A GraphQL document is valid only if it contains no introspection types.
+ */
+export function DisableIntrospectionQueries(context: ValidationContext): any {
+  return {
+    Field(node: FieldNode) {
+      const type = context.getType();
+      if (type) {
+        if (INTROSPECTION_TYPES.indexOf(String(type)) >= 0) {
+          context.reportError(
+            new GraphQLError(
+              noIntrospectionAllowedMessage(node.name.value, type),
+            ),
+          );
+        }
+      }
+    },
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import {
 import httpError from 'http-errors';
 import url from 'url';
 
+import { DisableIntrospectionQueries } from './disable-introspection';
 import { parseBody } from './parseBody';
 import { renderGraphiQL } from './renderGraphiQL';
 
@@ -92,6 +93,11 @@ export type OptionsData = {
    * A boolean to optionally enable GraphiQL mode.
    */
   graphiql?: ?boolean,
+
+  /**
+   * A boolean to optionally disable introspection queries.
+   */
+  introspectionDisabled?: ?boolean,
 };
 
 /**
@@ -187,6 +193,9 @@ function graphqlHTTP(options: Options): Middleware {
         let validationRules = specifiedRules;
         if (optionsData.validationRules) {
           validationRules = validationRules.concat(optionsData.validationRules);
+        }
+        if (optionsData.introspectionDisabled) {
+          validationRules = validationRules.concat(DisableIntrospectionQueries);
         }
 
         // GraphQL HTTP only supports GET and POST methods.


### PR DESCRIPTION
**What It Does**
This PR adds the option to apply an additional validation rule that disables query introspection. 

**Why**
In a production environment, allowing a 3rd party to run an inspection query is enough for them to figure out how to build any query they like. For the same reason that a company might want to turn off GraphiQL, they also might want to turn off this type of query. Ideally, queries are persisted at build time and GraphQL itself isn't accessible but there are a lot of people who expose GraphQL directly to consumers.

**How**
This PR adds to the existing GraphQL validation system by simply appending a new rule if the option is enabled.