### PR TITLE
Feature/document validation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,15 +245,11 @@ GraphQL's [validation phase](https://facebook.github.io/graphql/#sec-Validation)
 A validation rule is a function which returns a visitor for one or more node Types. Below is an example of a validation preventing the specific fieldname `metadata` from being queried. For more examples see the [`specifiedRules`](https://github.com/graphql/graphql-js/tree/master/src/validation/rules) in the [graphql-js](https://github.com/graphql/graphql-js) package.
 
 ```js
-/* @flow */
-
 import { GraphQLError } from 'graphql';
 
-import type { ValidationContext, FieldNode } from 'graphql';
-
-export function DisallowMetadataQueries(context: ValidationContext): any {
+export function DisallowMetadataQueries(context) {
   return {
-    Field(node: FieldNode) {
+    Field(node) {
       const fieldName = node.name.value;
 
       if (fieldName === "metadata") {

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ for example:
 
 GraphQL's [validation phase](https://facebook.github.io/graphql/#sec-Validation) checks the query to ensure that it can be sucessfully executed against the schema. The `validationRules` option allows for additional rules to be run during this phase. Rules are applied to each node in an AST representing the query using the Visitor pattern.
 
-A validation rules is a function which returns a visitor for one or more node Types. Below is an example of a validation preventing the specific fieldname `metadata` from being queried. For more examples see the [`specifiedRules`](https://github.com/graphql/graphql-js/tree/master/src/validation/rules) in the [graphql-js](https://github.com/graphql/graphql-js) package.
+A validation rule is a function which returns a visitor for one or more node Types. Below is an example of a validation preventing the specific fieldname `metadata` from being queried. For more examples see the [`specifiedRules`](https://github.com/graphql/graphql-js/tree/master/src/validation/rules) in the [graphql-js](https://github.com/graphql/graphql-js) package.
 
 ```js
 /* @flow */

--- a/README.md
+++ b/README.md
@@ -238,6 +238,36 @@ for example:
 ```
 
 
+## Additional Validation Rules
+
+GraphQL's [validation phase](https://facebook.github.io/graphql/#sec-Validation) checks the query to ensure that it can be sucessfully executed against the schema. The `validationRules` option allows for additional rules to be run durring this phase. Rules are applied to each node in an AST representing the query using the Visitor pattern.
+
+A validation rules is a function which returns a visitor for one or more node Types. Below is an example of a validation preventing the specific fieldname `metadata` from being queried. For more examples see the `specifiedRules` in the `graphql-js` package.
+
+```js
+/* @flow */
+
+import { GraphQLError } from 'graphql';
+
+import type { ValidationContext, FieldNode } from 'graphql';
+
+export function DisallowMetadataQueries(context: ValidationContext): any {
+  return {
+    Field(node: FieldNode) {
+      const fieldName = node.name.value;
+
+      if (fieldName === "metadata") {
+        context.reportError(
+          new GraphQLError(
+            `Validation: Requesting the field ${fieldName} is not allowed`,
+          ),
+        );
+      }
+    }
+  };
+}
+```
+
 ## Other Exports
 
 **`getGraphQLParams(request: Request): Promise<GraphQLParams>`**

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ for example:
 
 GraphQL's [validation phase](https://facebook.github.io/graphql/#sec-Validation) checks the query to ensure that it can be sucessfully executed against the schema. The `validationRules` option allows for additional rules to be run durring this phase. Rules are applied to each node in an AST representing the query using the Visitor pattern.
 
-A validation rules is a function which returns a visitor for one or more node Types. Below is an example of a validation preventing the specific fieldname `metadata` from being queried. For more examples see the `specifiedRules` in the `graphql-js` package.
+A validation rules is a function which returns a visitor for one or more node Types. Below is an example of a validation preventing the specific fieldname `metadata` from being queried. For more examples see the [`specifiedRules`](https://github.com/graphql/graphql-js/tree/master/src/validation/rules) in the [graphql-js](https://github.com/graphql/graphql-js) package.
 
 ```js
 /* @flow */

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ for example:
 
 ## Additional Validation Rules
 
-GraphQL's [validation phase](https://facebook.github.io/graphql/#sec-Validation) checks the query to ensure that it can be sucessfully executed against the schema. The `validationRules` option allows for additional rules to be run durring this phase. Rules are applied to each node in an AST representing the query using the Visitor pattern.
+GraphQL's [validation phase](https://facebook.github.io/graphql/#sec-Validation) checks the query to ensure that it can be sucessfully executed against the schema. The `validationRules` option allows for additional rules to be run during this phase. Rules are applied to each node in an AST representing the query using the Visitor pattern.
 
 A validation rules is a function which returns a visitor for one or more node Types. Below is an example of a validation preventing the specific fieldname `metadata` from being queried. For more examples see the [`specifiedRules`](https://github.com/graphql/graphql-js/tree/master/src/validation/rules) in the [graphql-js](https://github.com/graphql/graphql-js) package.
 


### PR DESCRIPTION
the `validationRUles` feature plugs into GraphQL's `validate` function which has quite a few requirements to work correctly. I wanted to take a crack at adding a bit more documentation and a few links that will help folks get up and running should they decide to add rules.

I considered adding more sophisticated documentation here but I think that really belongs in the `graphql-js` repo itself. If you're interested in having that PR I'd be happy to do it but since I didn't really see much high-level documentation in that repo (beyond function level docs) I figured I'd start with this.