### PR TITLE
return result from the last promise to continue with the promise chain

### DIFF
--- a/src/__tests__/usage-test.js
+++ b/src/__tests__/usage-test.js
@@ -34,7 +34,8 @@ describe('Useful errors when incorrectly used', () => {
     expect(JSON.parse(response.text)).to.deep.equal({
       errors: [
         {
-          message: 'GraphQL middleware option function must return an options object or a promise which will be resolved to an options object.',
+          message:
+            'GraphQL middleware option function must return an options object or a promise which will be resolved to an options object.',
         },
       ],
     });
@@ -51,7 +52,8 @@ describe('Useful errors when incorrectly used', () => {
     expect(JSON.parse(response.text)).to.deep.equal({
       errors: [
         {
-          message: 'GraphQL middleware option function must return an options object or a promise which will be resolved to an options object.',
+          message:
+            'GraphQL middleware option function must return an options object or a promise which will be resolved to an options object.',
         },
       ],
     });

--- a/src/index.js
+++ b/src/index.js
@@ -36,10 +36,10 @@ import type { $Request, $Response } from 'express';
  */
 export type Options =
   | ((
-    request: $Request,
-    response: $Response,
-    params?: GraphQLParams,
-  ) => OptionsResult)
+      request: $Request,
+      response: $Response,
+      params?: GraphQLParams,
+    ) => OptionsResult)
   | OptionsResult;
 export type OptionsResult = OptionsData | Promise<OptionsData>;
 export type OptionsData = {
@@ -119,7 +119,7 @@ export type RequestInfo = {
   result: ?mixed,
 };
 
-type Middleware = (request: $Request, response: $Response) => Promise<void>;
+type Middleware = (request: $Request, response: $Response) => Promise<mixed>;
 
 /**
  * Middleware for express; takes an options object or function as input to
@@ -316,7 +316,8 @@ function graphqlHTTP(options: Options): Middleware {
             operationName,
             result,
           });
-          return sendResponse(response, 'text/html', payload);
+          sendResponse(response, 'text/html', payload);
+          return result;
         }
 
         // At this point, result is guaranteed to exist, as the only scenario
@@ -334,6 +335,7 @@ function graphqlHTTP(options: Options): Middleware {
           const payload = JSON.stringify(result, null, pretty ? 2 : 0);
           sendResponse(response, 'application/json', payload);
         }
+        return result;
       });
   };
 }

--- a/src/parseBody.js
+++ b/src/parseBody.js
@@ -105,9 +105,10 @@ function read(req, typeInfo, parseFn, resolve, reject) {
 
   // Get content-encoding (e.g. gzip)
   const contentEncoding = req.headers['content-encoding'];
-  const encoding = typeof contentEncoding === 'string'
-    ? contentEncoding.toLowerCase()
-    : 'identity';
+  const encoding =
+    typeof contentEncoding === 'string'
+      ? contentEncoding.toLowerCase()
+      : 'identity';
   const length = encoding === 'identity' ? req.headers['content-length'] : null;
   const limit = 100 * 1024; // 100kb
   const stream = decompressed(req, encoding);


### PR DESCRIPTION
Right now there is now way to capture errors from the graphql middleware. one way to do it is to have a wrapper middleware. However for that to work the last promise should resolve with the result.

Refer the tests for example usage.

cc @leebyron @wincent @taion