### PR TITLE
Remove out-of-date contributors list

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,6 @@
   "name": "express-graphql",
   "version": "0.6.6",
   "description": "Production ready GraphQL HTTP middleware.",
-  "contributors": [
-    "Lee Byron <lee@leebyron.com> (http://leebyron.com/)",
-    "Daniel Schafer <dschafer@fb.com>",
-    "Caleb Meredith <calebmeredith8@gmail.com>"
-  ],
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/graphql/express-graphql/issues"


### PR DESCRIPTION
To see an up-to-date list, either run `git shortlog -s` in the repo or visit: https://github.com/graphql/express-graphql/graphs/contributors