### PR TITLE
let type of document to be optional on RequestInfo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ export type RequestInfo = {
   /**
    * The parsed GraphQL document.
    */
-  document: DocumentNode,
+  document: ?DocumentNode,
 
   /**
    * The variable values used at runtime.


### PR DESCRIPTION
`document` could be undefined if error be thrown when parsing AST.

https://github.com/graphql/express-graphql/blob/81fe7a4d9a1d2b7e21f40aac763a6f77ba273944/src/index.js#L144

https://github.com/graphql/express-graphql/blob/81fe7a4d9a1d2b7e21f40aac763a6f77ba273944/src/index.js#L213-L219

https://github.com/graphql/express-graphql/blob/81fe7a4d9a1d2b7e21f40aac763a6f77ba273944/src/index.js#L271-L276