### PR TITLE
Attempt fix for Travis failure to deploy to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "testonly": "mocha $npm_package_options_mocha",
     "lint": "eslint src",
     "check": "flow check",
-    "build": "rm -rf dist/* && babel src --ignore __tests__ --out-dir dist && npm run build:flow",
+    "build": "rm -rf dist/* && node_modules/.bin/babel src --ignore __tests__ --out-dir dist && npm run build:flow",
     "build:flow": "find ./src -name '*.js' -not -path '*/__tests__*' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\/src\\//\\/dist\\//g'`.flow; done",
     "watch": "node resources/watch.js",
     "cover": "babel-node node_modules/.bin/isparta cover --root src --report html node_modules/.bin/_mocha -- $npm_package_options_mocha",


### PR DESCRIPTION
See:

- https://github.com/graphql/express-graphql/issues/385
- https://travis-ci.org/graphql/express-graphql/jobs/269612343#L872
- https://travis-ci.org/graphql/express-graphql/jobs/269621779

It can't find `babel`, which makes me wonder if the `$PATH` is not being correctly set for some reason.

Previous release where the build worked fine; uses same "Trusty" Travis environment, NPM version etc:

- https://travis-ci.org/graphql/express-graphql/jobs/258623862

Tested with local `npm run build` but will need to do another version bump to see if Travis works with it.