### PR TITLE
Force install before build to fix Travis NPM deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "testonly": "mocha $npm_package_options_mocha",
     "lint": "eslint src",
     "check": "flow check",
-    "build": "rm -rf dist/* && node_modules/.bin/babel src --ignore __tests__ --out-dir dist && npm run build:flow",
+    "build": "rm -rf dist/* && babel src --ignore __tests__ --out-dir dist && npm run build:flow",
     "build:flow": "find ./src -name '*.js' -not -path '*/__tests__*' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\/src\\//\\/dist\\//g'`.flow; done",
     "watch": "node resources/watch.js",
     "cover": "babel-node node_modules/.bin/isparta cover --root src --report html node_modules/.bin/_mocha -- $npm_package_options_mocha",

--- a/resources/prepublish.sh
+++ b/resources/prepublish.sh
@@ -2,7 +2,7 @@
 # prepublish runs after `npm install` and `npm pack`.
 # In order to only run prepublish before `npm publish`, we have to check argv.
 if node -e "process.exit(($npm_config_argv).original[0].indexOf('pu') === 0)"; then
-  exit 0;
+  exit 0
 fi
 
 # Publishing to NPM is currently supported by Travis CI, which ensures that all
@@ -10,11 +10,12 @@ fi
 # In order to prevent inadvertently circumventing this, we ensure that a CI
 # environment exists before continuing.
 if [ "$CI" != true ]; then
-  echo "\n\n\n  \033[101;30m Only Travis CI can publish to NPM. \033[0m" 1>&2;
-  echo "  Ensure git is left is a good state by backing out any commits and deleting any tags." 1>&2;
-  echo "  Then read CONTRIBUTING.md to learn how to publish to NPM.\n\n\n" 1>&2;
-  exit 1;
-fi;
+  echo "\n\n\n  \033[101;30m Only Travis CI can publish to NPM. \033[0m" 1>&2
+  echo "  Ensure git is left is a good state by backing out any commits and deleting any tags." 1>&2
+  echo "  Then read CONTRIBUTING.md to learn how to publish to NPM.\n\n\n" 1>&2
+  exit 1
+fi
 
 # Build before Travis CI publishes to NPM
-npm run build;
+npm install
+npm run build


### PR DESCRIPTION
Buried in the error message:

    https://travis-ci.org/graphql/express-graphql/jobs/269654768

You can see:

> Local package.json exists, but node_modules missing, did you mean to install?

So, going to try an alternate fix from the one I attempted in 90aa430.

See: https://github.com/graphql/express-graphql/issues/385