### PR TITLE
Silence npm install output in Travis → NPM deploy

### DIFF
--- a/resources/prepublish.sh
+++ b/resources/prepublish.sh
@@ -17,5 +17,5 @@ if [ "$CI" != true ]; then
 fi
 
 # Build before Travis CI publishes to NPM
-npm install
+npm install > /dev/null 2>&1
 npm run build


### PR DESCRIPTION
Without this, the `npm install` output causes the logs to be truncated:

https://travis-ci.org/graphql/express-graphql/jobs/269661199

Note that I am using an old-school POSIX-compatible redirect of stderr and stdout (as opposed to the simpler `npm install &> /dev/null` because I don't know whether this script is going to be running as Bash or `/bin/sh` (which itself could be Bash, or something else).

Closes: https://github.com/graphql/express-graphql/issues/388