### PR TITLE
Allow to replace default execute function

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ The `graphqlHTTP` function accepts the following options:
   * **`customValidateFn`**: An optional function which will be used to validate
     instead of default `validate` from `graphql-js`.
 
+  * **`customExecuteFn`**: An optional function which will be used to execute
+    instead of default `execute` from `graphql-js`.
+
   * **`customFormatErrorFn`**:  An optional function which will be used to format any
     errors produced by fulfilling a GraphQL operation. If no function is
     provided, GraphQL's default spec-compliant [`formatError`][] function will be used.


### PR DESCRIPTION
This PR allows providing your own `execute` function instead of the default one from the `graphql-js`.
It’s a small change that adds a lot of flexibility since you can wrap standard `execute` and it opens new possibilities for middlewares. 

Personally, I need it to proxy calls to 3rd-party APIs.
It’s an alternative to #253 but introduces less code and more flexible mechanism.
It’s very important for us as it will be the last change required to switch [graphql-faker](https://github.com/APIs-guru/graphql-faker) from custom forks of `graphql-js` and `graphql-express`.
@wincent @leebyron Can you please review it?