### PR TITLE
Readable stack trace ftw instead of a difficult to read one liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ stack traces. Providing a function to `formatError` enables this:
 formatError: error => ({
   message: error.message,
   locations: error.locations,
-  stack: error.stack,
+  stack: error.stack ? error.stack.split('\n') : [],
   path: error.path
 })
 ```


### PR DESCRIPTION
A minor update to help users navigate the errors
![image](https://user-images.githubusercontent.com/1210516/30952109-bfacda12-a469-11e7-8e18-09a0e2666c7c.png)

previously it was a one liner

![image](https://user-images.githubusercontent.com/1210516/30952249-68980b38-a46a-11e7-99c7-71bc19720863.png)

