### PR TITLE
updated version of GraphiQL

### DIFF
--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -16,7 +16,7 @@ type GraphiQLData = {
 };
 
 // Current latest version of GraphiQL.
-const GRAPHIQL_VERSION = '0.11.5';
+const GRAPHIQL_VERSION = '0.11.11';
 
 // Ensures string values are safe to be used within a <script> tag.
 function safeSerialize(data) {

--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -16,7 +16,7 @@ type GraphiQLData = {
 };
 
 // Current latest version of GraphiQL.
-const GRAPHIQL_VERSION = '0.11.2';
+const GRAPHIQL_VERSION = '0.11.5';
 
 // Ensures string values are safe to be used within a <script> tag.
 function safeSerialize(data) {


### PR DESCRIPTION
The updated version of GraphiQL should fix error-highlighting and tool tips, which are not working with the current version `0.11.2`.

This pull request fixes #396