### PR TITLE
Use a named function for the middleware over an anonymous

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,7 @@ function graphqlHTTP(options: Options): Middleware {
     throw new Error('GraphQL middleware requires options.');
   }
 
-  return function graphql(request: $Request, response: $Response) {
+  return function graphqlMiddleware(request: $Request, response: $Response) {
     // Higher scoped variables are referred to at various stages in the
     // asynchronous state machine below.
     let params;

--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,7 @@ function graphqlHTTP(options: Options): Middleware {
     throw new Error('GraphQL middleware requires options.');
   }
 
-  return (request: $Request, response: $Response) => {
+  return function graphql(request: $Request, response: $Response) {
     // Higher scoped variables are referred to at various stages in the
     // asynchronous state machine below.
     let params;


### PR DESCRIPTION
It's making the investigation of performance issues easier.

**New Relic**
<img width="654" alt="capture d ecran 2018-02-09 a 18 16 21" src="https://user-images.githubusercontent.com/3165635/36040311-5de7b9c6-0dc5-11e8-8151-eb36d637f014.png">

**Chrome Dev Tool**

<img width="247" alt="capture d ecran 2018-02-09 a 18 21 47" src="https://user-images.githubusercontent.com/3165635/36040570-2703d722-0dc6-11e8-9f94-f8a80938fe7f.png">

Related to:
- https://github.com/i18next/i18next-express-middleware/pull/144
- https://github.com/helmetjs/helmet/pull/165
- https://github.com/getsentry/raven-node/pull/424