### PR TITLE
Set 500 status code when graphql returns a result with no data

### DIFF
--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -263,7 +263,7 @@ describe('test harness', () => {
           }),
         );
 
-        expect(response.status).to.equal(200);
+        expect(response.status).to.equal(500);
         expect(JSON.parse(response.text)).to.deep.equal({
           errors: [
             {
@@ -1432,6 +1432,36 @@ describe('test harness', () => {
         expect(response.status).to.equal(400);
         expect(JSON.parse(response.text)).to.deep.equal({
           errors: [{ message: 'Variables are invalid JSON.' }],
+        });
+      });
+
+      it('handles invalid variables', async () => {
+        const app = server();
+
+        post(
+          app,
+          urlString(),
+          graphqlHTTP({
+            schema: TestSchema,
+          }),
+        );
+
+        const response = await request(app)
+          .post(urlString())
+          .send({
+            query: 'query helloWho($who: String){ test(who: $who) }',
+            variables: { who: ['Dolly', 'Jonty'] },
+          });
+
+        expect(response.status).to.equal(500);
+        expect(JSON.parse(response.text)).to.deep.equal({
+          errors: [
+            {
+              locations: [{ column: 16, line: 1 }],
+              message:
+                'Variable "$who" got invalid value ["Dolly","Jonty"].\nExpected type "String", found ["Dolly","Jonty"]: String cannot represent an array value: [Dolly,Jonty]',
+            },
+          ],
         });
       });
 

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -1459,7 +1459,7 @@ describe('test harness', () => {
             {
               locations: [{ column: 16, line: 1 }],
               message:
-                'Variable "$who" got invalid value ["Dolly","Jonty"].\nExpected type "String", found ["Dolly","Jonty"]: String cannot represent an array value: [Dolly,Jonty]',
+                'Variable "$who" got invalid value ["Dolly","Jonty"]; Expected type String; String cannot represent an array value: [Dolly,Jonty]',
             },
           ],
         });

--- a/src/index.js
+++ b/src/index.js
@@ -294,7 +294,7 @@ function graphqlHTTP(options: Options): Middleware {
         // Note: Information about the error itself will still be contained in
         // the resulting JSON payload.
         // http://facebook.github.io/graphql/#sec-Data
-        if (result && result.data === null) {
+        if (response.statusCode === 200 && result && !result.data) {
           response.statusCode = 500;
         }
         // Format any encountered errors.


### PR DESCRIPTION
Fix #417 by returning a 500 HTTP status code when query variables are invalidated during execution (or whenever graphql returns a result with no data property)