### PR TITLE
Custom error formatting does not work when parameters are malformed

### DIFF
--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -1433,6 +1433,37 @@ describe('test harness', () => {
         });
       });
 
+      it('allows for custom error formatting of poorly formed requests', async () => {
+        const app = server();
+
+        get(
+          app,
+          urlString(),
+          graphqlHTTP({
+            schema: TestSchema,
+            formatError(error) {
+              return { message: 'Custom error format: ' + error.message };
+            },
+          }),
+        );
+
+        const response = await request(app).get(
+          urlString({
+            variables: 'who:You',
+            query: 'query helloWho($who: String){ test(who: $who) }',
+          }),
+        );
+
+        expect(response.status).to.equal(400);
+        expect(JSON.parse(response.text)).to.deep.equal({
+          errors: [
+            {
+              message: 'Custom error format: Variables are invalid JSON.',
+            },
+          ],
+        });
+      });
+
       it('handles invalid variables', async () => {
         const app = server();
 


### PR DESCRIPTION
When any of the core GraphQL parameters are malformed, custom error formatting stops working, and instead errors are returned in the default GraphQL flavor.

This happens for all of the following errors:
- POST body sent invalid JSON.
- Unsupported charset
- Invalid body
- Unsupported content-encoding
- Variables are invalid JSON
- Any other errors that occur when parsing body, e.g. uncompressing errors

When parameters are malformed the code to set`formatErrFn` is [never reached](https://github.com/graphql/express-graphql/blob/master/src/index.js#L181), so errors fallback to the default GraphQL error function.

This change will instead invoke the options parsing function when parameters fail to parse with the specific intention of extracting the `formatError` function for use in reporting the error. A dummy parameters (with all values set to null) is passed to the options function, since it seems likely that existing clients rely on the object itself existing.