### PR TITLE
WIP: allow the user to disable HTTP 500 if the response contains only errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The `graphqlHTTP` function accepts the following options:
 
   * **`pretty`**: If `true`, any JSON response will be pretty-printed.
 
+  * **`httpErrorOnEmptyData`**: If `false`, the HTTP status code of the response will not be set to 500 if the response contains only errors, not data.
+
   * **`formatError`**: An optional function which will be used to format any
     errors produced by fulfilling a GraphQL operation. If no function is
     provided, GraphQL's default spec-compliant [`formatError`][] function will be used.

--- a/src/index.js
+++ b/src/index.js
@@ -86,8 +86,6 @@ export type OptionsData = {
    */
   formatError?: ?(error: GraphQLError) => mixed,
 
-
-
   /**
    * An optional array of validation rules that will be applied on the document
    * in additional to those defined by the GraphQL spec.

--- a/src/index.js
+++ b/src/index.js
@@ -73,11 +73,20 @@ export type OptionsData = {
   pretty?: ?boolean,
 
   /**
+   * A boolean to configure whether HTTP status code should be set to 500
+   * if the query did not return any data.
+   * True by default.
+   */
+  httpErrorOnEmptyData?: ?boolean,
+
+  /**
    * An optional function which will be used to format any errors produced by
    * fulfilling a GraphQL operation. If no function is provided, GraphQL's
    * default spec-compliant `formatError` function will be used.
    */
   formatError?: ?(error: GraphQLError) => mixed,
+
+
 
   /**
    * An optional array of validation rules that will be applied on the document
@@ -158,6 +167,7 @@ function graphqlHTTP(options: Options): Middleware {
     let context;
     let params;
     let pretty;
+    let httpErrorOnEmptyData;
     let formatErrorFn;
     let extensionsFn;
     let showGraphiQL;
@@ -203,6 +213,7 @@ function graphqlHTTP(options: Options): Middleware {
         const graphiql = optionsData.graphiql;
 
         context = optionsData.context || request;
+        httpErrorOnEmptyData = optionsData.httpErrorOnEmptyData !== false;
 
         let validationRules = specifiedRules;
         if (optionsData.validationRules) {
@@ -328,7 +339,7 @@ function graphqlHTTP(options: Options): Middleware {
         // Note: Information about the error itself will still be contained in
         // the resulting JSON payload.
         // http://facebook.github.io/graphql/#sec-Data
-        if (response.statusCode === 200 && result && !result.data) {
+        if (httpErrorOnEmptyData == && response.statusCode === 200 && result && !result.data) {
           response.statusCode = 500;
         }
         // Format any encountered errors.

--- a/src/index.js
+++ b/src/index.js
@@ -337,7 +337,7 @@ function graphqlHTTP(options: Options): Middleware {
         // Note: Information about the error itself will still be contained in
         // the resulting JSON payload.
         // http://facebook.github.io/graphql/#sec-Data
-        if (httpErrorOnEmptyData === && response.statusCode === 200 && result && !result.data) {
+        if (httpErrorOnEmptyData && response.statusCode === 200 && result && !result.data) {
           response.statusCode = 500;
         }
         // Format any encountered errors.

--- a/src/index.js
+++ b/src/index.js
@@ -337,7 +337,12 @@ function graphqlHTTP(options: Options): Middleware {
         // Note: Information about the error itself will still be contained in
         // the resulting JSON payload.
         // http://facebook.github.io/graphql/#sec-Data
-        if (httpErrorOnEmptyData && response.statusCode === 200 && result && !result.data) {
+        if (
+          httpErrorOnEmptyData &&
+          response.statusCode === 200 &&
+          result &&
+          !result.data
+        ) {
           response.statusCode = 500;
         }
         // Format any encountered errors.

--- a/src/index.js
+++ b/src/index.js
@@ -337,7 +337,7 @@ function graphqlHTTP(options: Options): Middleware {
         // Note: Information about the error itself will still be contained in
         // the resulting JSON payload.
         // http://facebook.github.io/graphql/#sec-Data
-        if (httpErrorOnEmptyData == && response.statusCode === 200 && result && !result.data) {
+        if (httpErrorOnEmptyData === && response.statusCode === 200 && result && !result.data) {
           response.statusCode = 500;
         }
         // Format any encountered errors.


### PR DESCRIPTION
By default, the `express-graphql` library changes the HTTP response code to 500 if the `response.data` property is falsy.
As a back-end developer, I want to be able to decide whether to respond with HTTP 200 or HTTP 500, even if the response contains no `data`, just `errors`.