### PR TITLE
Add support for customParseFn option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The `graphqlHTTP` function accepts the following options:
     errors produced by fulfilling a GraphQL operation. If no function is
     provided, GraphQL's default spec-compliant [`formatError`][] function will be used.
 
+  * **`customParseFn`**: An optional function which will be used to create a document
+    instead of the default `parse` from `graphql-js`.
+
   * **`formatError`**: is deprecated and replaced by `customFormatErrorFn`. It will be
     removed in version 1.0.0.
 

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -28,8 +28,10 @@ import {
   GraphQLString,
   GraphQLError,
   BREAK,
+  Source,
   validate,
   execute,
+  parse,
 } from 'graphql';
 import graphqlHTTP from '../';
 
@@ -2029,6 +2031,56 @@ describe('test harness', () => {
           '{"data":{"test":"Hello World","test2":"Modification"}}',
         );
         expect(seenExecuteArgs).to.not.equal(null);
+      });
+    });
+
+    describe('Custom parse function', () => {
+      it('can replace default parse functionality', async () => {
+        const app = server();
+
+        let seenParseArgs;
+
+        get(
+          app,
+          urlString(),
+          graphqlHTTP(() => {
+            return {
+              schema: TestSchema,
+              customParseFn(args) {
+                seenParseArgs = args;
+                return parse(new Source('{test}', 'Custom parse function'));
+              },
+            };
+          }),
+        );
+
+        const response = await request(app).get(urlString({ query: '----' }));
+
+        expect(response.status).to.equal(200);
+        expect(response.text).to.equal('{"data":{"test":"Hello World"}}');
+        expect(seenParseArgs).property('query', '----');
+      });
+      it('can throw errors', async () => {
+        const app = server();
+        get(
+          app,
+          urlString(),
+          graphqlHTTP(() => {
+            return {
+              schema: TestSchema,
+              customParseFn() {
+                throw new GraphQLError('my custom parse error');
+              },
+            };
+          }),
+        );
+
+        const response = await request(app).get(urlString({ query: '----' }));
+
+        expect(response.status).to.equal(400);
+        expect(response.text).to.equal(
+          '{"errors":[{"message":"my custom parse error"}]}',
+        );
       });
     });
 

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -2058,7 +2058,7 @@ describe('test harness', () => {
 
         expect(response.status).to.equal(200);
         expect(response.text).to.equal('{"data":{"test":"Hello World"}}');
-        expect(seenParseArgs).property('query', '----');
+        expect(seenParseArgs).property('body', '----');
       });
       it('can throw errors', async () => {
         const app = server();

--- a/src/index.js
+++ b/src/index.js
@@ -272,7 +272,7 @@ function graphqlHTTP(options: Options): Middleware {
         }
 
         //  GraphQL source.
-        const source = new Source(query);
+        const source = new Source(query, 'GraphQL request');
 
         // Parse source to AST, reporting any syntax error.
         try {

--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ export type OptionsData = {
    * An optional function which will be used to create a document instead of
    * the default `parse` from `graphql-js`.
    */
-  customParseFn?: ?(params: GraphQLParams) => DocumentNode,
+  customParseFn?: ?(source: Source) => DocumentNode,
 
   /**
    * `formatError` is deprecated and replaced by `customFormatErrorFn`. It will
@@ -192,7 +192,7 @@ function graphqlHTTP(options: Options): Middleware {
     let formatErrorFn = formatError;
     let validateFn = validate;
     let executeFn = execute;
-    let parseFn = defaultParseFn;
+    let parseFn = parse;
     let extensionsFn;
     let showGraphiQL;
     let query;
@@ -271,9 +271,12 @@ function graphqlHTTP(options: Options): Middleware {
           return { errors: schemaValidationErrors };
         }
 
+        //  GraphQL source.
+        const source = new Source(query);
+
         // Parse source to AST, reporting any syntax error.
         try {
-          documentAST = parseFn(params);
+          documentAST = parseFn(source);
         } catch (syntaxError) {
           // Return 400: Bad Request if any syntax errors errors exist.
           response.statusCode = 400;
@@ -508,11 +511,4 @@ function sendResponse(response: $Response, type: string, data: string): void {
   response.setHeader('Content-Type', type + '; charset=utf-8');
   response.setHeader('Content-Length', String(chunk.length));
   response.end(chunk);
-}
-
-/**
- * Helper function to provide the default parse functionality.
- */
-function defaultParseFn(params: GraphQLParams): DocumentNode {
-  return parse(new Source(params.query || '', 'GraphQL request'));
 }


### PR DESCRIPTION
Attempt to address #483.

The current implementation in this PR provides support for synchronous `customParseFn` functions.

Eventually I think that it would be worthwhile also supporting asynchronous functions. i.e. have the `customParseFn` return type be a (let's see if i get the Flow type correct) `?Promise<DocumentNode>`.  Unfortunitely I couldn't quite get the promise handling `.then().catch()` logic right at this point in time... even when requiring the `customParseFn` be async (vs. maybe async).