### PR TITLE
Auto prettify

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `graphqlHTTP` function accepts the following options:
   * **`graphiql`**: If `true`, presents [GraphiQL][] when the GraphQL endpoint is
     loaded in a browser. We recommend that you set
     `graphiql` to `true` when your app is in development, because it's
-    quite useful. You may or may not want it in production.
+    quite useful. You may or may not want it in production. Alternatively, instead of `true` you can pass in an options object that currently supports a single field called `autoPrettify`. When setting that field to `true`, the GraphQL queries are automatically pretty printed when opened in GraphiQL.
 
   * **`rootValue`**: A value to pass as the `rootValue` to the `graphql()`
     function from [`GraphQL.js/src/execute.js`](https://github.com/graphql/graphql-js/blob/master/src/execution/execute.js#L119).

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,10 @@ export type Options =
   | OptionsResult;
 export type OptionsResult = OptionsData | Promise<OptionsData>;
 
+type GraphiQLOptions = {|
+  autoPrettify: boolean,
+|};
+
 export type OptionsData = {|
   /**
    * A GraphQL schema from graphql-js.
@@ -129,7 +133,7 @@ export type OptionsData = {|
   /**
    * A boolean to optionally enable GraphiQL mode.
    */
-  graphiql?: ?boolean,
+  graphiql?: ?boolean | ?GraphiQLOptions,
 
   /**
    * A resolver function to use when one is not provided by the schema.
@@ -378,11 +382,15 @@ function graphqlHTTP(options: Options): Middleware {
 
         // If allowed to show GraphiQL, present it instead of JSON.
         if (showGraphiQL) {
+          const autoPrettify = Boolean(
+            typeof showGraphiQL === 'object' && showGraphiQL.autoPrettify,
+          );
           const payload = renderGraphiQL({
             query,
             variables,
             operationName,
             result,
+            autoPrettify,
           });
           return sendResponse(response, 'text/html', payload);
         }

--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -14,6 +14,7 @@ type GraphiQLData = {|
   variables: ?{ [name: string]: mixed },
   operationName: ?string,
   result?: mixed,
+  autoPrettify?: boolean,
 |};
 
 // Current latest version of GraphiQL.
@@ -40,6 +41,7 @@ export function renderGraphiQL(data: GraphiQLData): string {
     ? JSON.stringify(data.result, null, 2)
     : null;
   const operationName = data.operationName;
+  const autoPrettify = data.autoPrettify;
 
   return `<!--
 The request to this GraphQL server provided the header "Accept: text/html"
@@ -158,6 +160,7 @@ add "&raw" to the end of the URL within a browser.
         response: ${safeSerialize(resultString)},
         variables: ${safeSerialize(variablesString)},
         operationName: ${safeSerialize(operationName)},
+        ${autoPrettify ? 'autoPrettify: true,' : ''}
       }),
       document.getElementById('graphiql')
     );


### PR DESCRIPTION
Dependent on https://github.com/graphql/graphiql/pull/830

Extends the `graphiql` option to alternatively accept an object instead of a boolean. This object has a field called `autoPrettify` that when set to `true` will pass the `autoPrettify` prop to the GraphiQL component, that will in turn run the prettify method when it mounts. This means stripped GraphQL queries will automatically be pretty printed when opened in the GraphiQL editor.