### PR TITLE
Fix flow type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-flowtype": "3.9.0",
     "eslint-plugin-prettier": "3.1.0",
     "express": "4.17.0",
-    "flow-bin": "0.96.0",
+    "flow-bin": "0.102.0",
     "graphql": "14.3.0",
     "mocha": "6.1.4",
     "multer": "1.4.1",

--- a/src/index.js
+++ b/src/index.js
@@ -475,6 +475,8 @@ function parseGraphQLParams(
     }
   } else if (typeof variables !== 'object') {
     variables = null;
+  } else {
+    variables = { ...variables };
   }
 
   // Name of GraphQL operation to execute.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1661,10 +1661,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
-flow-bin@0.96.0:
-  version "0.96.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.96.0.tgz#3b0379d97304dc1879ae6db627cd2d6819998661"
-  integrity sha512-OSxERs0EdhVxEVCst/HmlT/RcnXsQQIRqcfK9J9wC8/93JQj+xQz4RtlsmYe1PSRYaozuDLyPS5pIA81Zwzaww==
+flow-bin@0.102.0:
+  version "0.102.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.102.0.tgz#3d5de44bcc26d26585e932b3201988b766f9b380"
+  integrity sha512-mYon6noeLO0Q5SbiWULLQeM1L96iuXnRtYMd47j3bEWXAwUW9EnwNWcn+cZg/jC/Dg4Wj/jnkdTDEuFtbeu1ww==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
`mixed` had changed, after [flow@0.98.0](https://github.com/facebook/flow/releases/tag/v0.98.0):

- `mixed` refined to an array produces a read-only array.
- `mixed` refined to an object produces a read-only object.