### PR TITLE
Fix GraphiQL font rendering

### DIFF
--- a/src/renderGraphiQL.js
+++ b/src/renderGraphiQL.js
@@ -69,7 +69,7 @@ add "&raw" to the end of the URL within a browser.
     }
   </style>
   <style>
-    // graphiql/graphiql.css
+    /* graphiql/graphiql.css */
     ${loadFileStaticlyFromNPM('graphiql/graphiql.css')}
   </style>
   <script>


### PR DESCRIPTION
The GraphiQL page-level font-family CSS rules are not applying because the `renderGraphiQL.js` page uses a JS-type comment in a `<style>` block.

This PR is a quick fix to change to use the CSS style comment `/* ... */` so that
the first CSS rule doesn't get skipped.

Before

<img width="1040" alt="Screen Shot 2019-11-08 at 12 15 21 PM" src="https://user-images.githubusercontent.com/93245/68500722-fcff7d80-0221-11ea-9899-0b60a3c63ddc.png">


After

<img width="1037" alt="Screen Shot 2019-11-08 at 12 15 46 PM" src="https://user-images.githubusercontent.com/93245/68500729-fffa6e00-0221-11ea-9e57-b3d2be62dfec.png">
