### PR TITLE
Move graphql dependency to correct section

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "accepts": "^1.3.7",
     "content-type": "^1.0.4",
+    "graphql": "14.5.8",
     "http-errors": "^1.7.3",
     "raw-body": "^2.4.1"
   },
@@ -64,7 +65,6 @@
     "express": "4.17.1",
     "flow-bin": "0.112.0",
     "graphiql": "^0.14.0",
-    "graphql": "14.5.8",
     "mocha": "6.2.2",
     "multer": "1.4.2",
     "nyc": "14.1.1",


### PR DESCRIPTION
The graphql dependency is currently under the devDependencies section so causes missing module errors when included in a project.