### PR TITLE
Fix customExecuteFn return type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,9 @@ export type OptionsData = {|
    * An optional function which will be used to execute instead of default `execute`
    * from `graphql-js`.
    */
-  customExecuteFn?: ?(args: ExecutionArgs) => Promise<ExecutionResult>,
+  customExecuteFn?: ?(
+    args: ExecutionArgs,
+  ) => ExecutionResult | Promise<ExecutionResult>,
 
   /**
    * An optional function which will be used to format any errors produced by

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -85,7 +85,7 @@ declare namespace graphqlHTTP {
      * from `graphql-js`.
      */
     customExecuteFn?:
-      | ((args: ExecutionArgs) => Promise<ExecutionResult>)
+      | ((args: ExecutionArgs) => ExecutionResult | Promise<ExecutionResult>)
       | null;
 
     /**


### PR DESCRIPTION
Make `customExecuteFn` returns `ExecutionResult | Promise<ExecutionResult>` similar to [`graphql.execute`](https://github.com/graphql/graphql-js/blob/278bde0a5cd71008452b555065f19dcd1160270a/src/execution/execute.js#L141-L144).