### PR TITLE
Refactor TS declaration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:ci": "npm ci && npm run prettier:check && npm run lint && npm run check && npm run testonly:cover && npm run build && npm run check:integrations",
     "testonly": "mocha src/**/__tests__/**/*.js",
     "testonly:cover": "nyc npm run testonly",
-    "lint": "eslint src types resources integrationTests",
+    "lint": "eslint src resources integrationTests",
     "prettier": "prettier --ignore-path .gitignore --write --list-different '**/*.{js,ts,md,json,yml}'",
     "prettier:check": "prettier --ignore-path .gitignore --check '**/*.{js,ts,md,json,yml}'",
     "check": "flow check",

--- a/resources/build.js
+++ b/resources/build.js
@@ -25,10 +25,11 @@ if (require.main === module) {
 
       const cjs = babelBuild(srcPath, { envName: 'cjs' });
       fs.writeFileSync(destPath, cjs);
+    } else if (filepath.endsWith('d.ts')) {
+      fs.copyFileSync(srcPath, destPath);
     }
   }
 
-  fs.copyFileSync('./types/index.d.ts', './dist/index.d.ts');
   fs.copyFileSync('./LICENSE', './dist/LICENSE');
   fs.copyFileSync('./README.md', './dist/README.md');
 

--- a/src/__tests__/http-test.js
+++ b/src/__tests__/http-test.js
@@ -29,6 +29,15 @@ import {
 
 import { graphqlHTTP } from '../index';
 
+// TODO Improve typings after converting to TypeScript
+type Server = () => {|
+  get: (...args: Array<mixed>) => mixed,
+  post: (...args: Array<mixed>) => mixed,
+  put: (...args: Array<mixed>) => mixed,
+  request: () => any,
+  use: (...args: Array<mixed>) => any,
+|};
+
 const QueryRootType = new GraphQLObjectType({
   name: 'QueryRoot',
   fields: {
@@ -137,7 +146,7 @@ describe('GraphQL-HTTP tests for restify', () => {
   });
 });
 
-function runTests(server) {
+function runTests(server: Server) {
   describe('GET functionality', () => {
     it('allows GET with query param', async () => {
       const app = server();

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,10 +16,15 @@ import {
   GraphQLTypeResolver,
 } from 'graphql';
 
+import { GraphiQLOptions } from './renderGraphiQL';
+
 export {};
 
 type Request = IncomingMessage;
+
 type Response = ServerResponse & { json?: (data: unknown) => void };
+
+type Middleware = (request: Request, response: Response) => Promise<void>;
 
 /**
  * Used to configure the graphqlHTTP middleware by providing a schema
@@ -36,15 +41,6 @@ export type Options =
     ) => OptionsResult)
   | OptionsResult;
 type OptionsResult = OptionsData | Promise<OptionsData>;
-
-export interface GraphiQLOptions {
-  /**
-   * An optional GraphQL string to use when no query is provided and no stored
-   * query exists from a previous session.  If undefined is provided, GraphiQL
-   * will use its own default query.
-   */
-  defaultQuery?: string;
-}
 
 export interface OptionsData {
   /**
@@ -175,7 +171,11 @@ export interface RequestInfo {
   context?: unknown;
 }
 
-type Middleware = (request: Request, response: Response) => Promise<void>;
+/**
+ * Middleware for express; takes an options object or function as input to
+ * configure behavior, and returns an express middleware.
+ */
+export function graphqlHTTP(options: Options): Middleware;
 
 export interface GraphQLParams {
   query: string | null;
@@ -184,8 +184,4 @@ export interface GraphQLParams {
   raw: boolean;
 }
 
-/**
- * Middleware for express; takes an options object or function as input to
- * configure behavior, and returns an express middleware.
- */
-export function graphqlHTTP(options: Options): Middleware;
+export function getGraphQLParams(request: Request): Promise<GraphQLParams>;

--- a/src/parseBody.d.ts
+++ b/src/parseBody.d.ts
@@ -1,0 +1,7 @@
+import { IncomingMessage } from 'http';
+
+export {};
+
+type Request = IncomingMessage & { body?: unknown };
+
+export function parseBody(req: Request): Promise<{ [param: string]: unknown }>;

--- a/src/renderGraphiQL.d.ts
+++ b/src/renderGraphiQL.d.ts
@@ -1,0 +1,29 @@
+import { ExecutionResult } from 'graphql';
+
+export interface GraphiQLData {
+  query?: string | null;
+  variables?: { readonly [name: string]: unknown } | null;
+  operationName?: string | null;
+  result?: ExecutionResult;
+}
+
+export interface GraphiQLOptions {
+  /**
+   * An optional GraphQL string to use when no query is provided and no stored
+   * query exists from a previous session.  If undefined is provided, GraphiQL
+   * will use its own default query.
+   */
+  defaultQuery?: string;
+}
+
+/**
+ * When express-graphql receives a request which does not Accept JSON, but does
+ * Accept HTML, it may present GraphiQL, the in-browser GraphQL explorer IDE.
+ *
+ * When shown, it will be pre-populated with the result of having executed the
+ * requested query.
+ */
+export function renderGraphiQL(
+  data: GraphiQLData,
+  options?: GraphiQLOptions,
+): string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "lib": ["es6", "esnext.asynciterable"],
+    "lib": ["es2018", "esnext.asynciterable"],
+    "target": "es2018",
+    "moduleResolution": "node",
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,


### PR DESCRIPTION
This PR moves the type declarations inside `src` and splits them up by file. It also moves `tsconfig.ts` into the project root and makes some necessary changes to keep dtslint working.