### PR TITLE
Fix import inside example

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -1,7 +1,8 @@
 import express from 'express';
 import { buildSchema } from 'graphql';
 
-import { graphqlHTTP } from '../src';
+// eslint-disable-next-line node/no-missing-import, import/no-unresolved
+import { graphqlHTTP } from 'graphql-express';
 
 // Construct a schema, using GraphQL schema language
 const schema = buildSchema(`


### PR DESCRIPTION
This example won't be runnable anymore since a JS file can't import anything directly from `src`. We could make it a TS file, or just disable the lint warnings, in which case we might as well change the import to the actual library name as well.