### PR TITLE
Allow custom handling of runtime query errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ The `graphqlHTTP` function accepts the following options:
 - **`formatError`**: is deprecated and replaced by `customFormatErrorFn`. It will be
   removed in version 1.0.0.
 
+- **`handleRuntimeQueryErrorFn`**: An optional function which can be used to change the status code
+  or headers of the response in case of a runtime query error. By default, the status code is set to
+  `500`.
+
 In addition to an object defining each option, options can also be provided as
 a function (or async function) which returns this options object. This function
 is provided the arguments `(request, response, graphQLParams)` and is called

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,15 @@ export interface OptionsData {
   formatError?: (error: GraphQLError) => GraphQLFormattedError;
 
   /**
+   * Use this to modify the response when a runtime query error occurs. By
+   * default the statusCode will be set to 500.
+   */
+  handleRuntimeQueryErrorFn?: (
+    result: ExecutionResult,
+    response: Response,
+  ) => void;
+
+  /**
    * An optional function for adding additional metadata to the GraphQL response
    * as a key-value object. The result will be added to "extensions" field in
    * the resulting JSON. This is often a useful place to add development time
@@ -201,6 +210,7 @@ export function graphqlHTTP(options: Options): Middleware {
     let formatErrorFn = formatError;
     let pretty = false;
     let result: ExecutionResult;
+    let optionsData: OptionsData | undefined;
 
     try {
       // Parse the Request to get GraphQL request parameters.
@@ -209,7 +219,7 @@ export function graphqlHTTP(options: Options): Middleware {
       } catch (error) {
         // When we failed to parse the GraphQL parameters, we still need to get
         // the options object, so make an options call to resolve just that.
-        const optionsData = await resolveOptions();
+        optionsData = await resolveOptions();
         pretty = optionsData.pretty ?? false;
         formatErrorFn =
           optionsData.customFormatErrorFn ??
@@ -219,7 +229,7 @@ export function graphqlHTTP(options: Options): Middleware {
       }
 
       // Then, resolve the Options to get OptionsData.
-      const optionsData: OptionsData = await resolveOptions(params);
+      optionsData = await resolveOptions(params);
 
       // Collect information from the options data object.
       const schema = optionsData.schema;
@@ -373,13 +383,22 @@ export function graphqlHTTP(options: Options): Middleware {
       result = { data: undefined, errors: error.graphqlErrors ?? [error] };
     }
 
-    // If no data was included in the result, that indicates a runtime query
-    // error, indicate as such with a generic status code.
-    // Note: Information about the error itself will still be contained in
-    // the resulting JSON payload.
-    // https://graphql.github.io/graphql-spec/#sec-Data
-    if (response.statusCode === 200 && result.data == null) {
-      response.statusCode = 500;
+    if (result.errors != null || result.data == null) {
+      const handleRuntimeQueryErrorFn =
+        optionsData?.handleRuntimeQueryErrorFn ??
+        ((_result, _response) => {
+          // If no data was included in the result, that indicates a runtime query
+          // error, indicate as such with a generic status code.
+          // Note: Information about the error itself will still be contained in
+          // the resulting JSON payload.
+          // https://graphql.github.io/graphql-spec/#sec-Data
+
+          if (_response.statusCode === 200 && _result.data == null) {
+            _response.statusCode = 500;
+          }
+        });
+
+      handleRuntimeQueryErrorFn(result, response);
     }
 
     // Format any encountered errors.


### PR DESCRIPTION
Since the earlier PRs were either not ready or not flexible enough I decided to take another shot at this issue. 

Closes #427.

Replaces the following PRs:
Closes #471. 
Closes #443.
