### PR TITLE
Validate static schema on middleware mount

### DIFF
--- a/src/__tests__/usage-test.ts
+++ b/src/__tests__/usage-test.ts
@@ -117,4 +117,17 @@ describe('Useful errors when incorrectly used', () => {
       ],
     });
   });
+
+  it('requires a valid schema if static scheme is defined in options', () => {
+    expect(() => {
+      // @ts-expect-error
+      graphqlHTTP({ schema: new GraphQLSchema({ directives: [null] }) });
+    }).to.throw('GraphQL schema validation failed');
+    expect(() => {
+      graphqlHTTP(() => ({
+        // @ts-expect-error
+        schema: new GraphQLSchema({ directives: [null] }),
+      }));
+    }).not.to.throw();
+  });
 });

--- a/src/__tests__/usage-test.ts
+++ b/src/__tests__/usage-test.ts
@@ -118,7 +118,7 @@ describe('Useful errors when incorrectly used', () => {
     });
   });
 
-  it('requires a valid schema if static scheme is defined in options', () => {
+  it('requires a valid schema if static schema is defined in options', () => {
     expect(() => {
       // @ts-expect-error
       graphqlHTTP({ schema: new GraphQLSchema({ directives: [null] }) });

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,6 +190,12 @@ export function graphqlHTTP(options: Options): Middleware {
     throw new Error('GraphQL middleware requires options.');
   }
 
+  const staticSchemaValidationErrors =
+    'schema' in options ? validateSchema(options.schema) : undefined;
+
+  if (staticSchemaValidationErrors?.length) {
+    throw Error('GraphQL schema validation failed');
+  }
   return async function graphqlMiddleware(
     request: Request,
     response: Response,
@@ -272,7 +278,8 @@ export function graphqlHTTP(options: Options): Middleware {
       }
 
       // Validate Schema
-      const schemaValidationErrors = validateSchema(schema);
+      const schemaValidationErrors =
+        staticSchemaValidationErrors ?? validateSchema(schema);
       if (schemaValidationErrors.length > 0) {
         // Return 500: Internal Server Error if invalid schema.
         throw httpError(500, 'GraphQL schema validation error.', {


### PR DESCRIPTION
**Problem:**
Static schema only gets validated on the first request, which causes server to successfully start and pass health checks 

**Solution:**
If static schema is provided - validate it on mount and throw an error if validation fails
