### PR TITLE
Fix type for customFormatErrorFn

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "start": "node -r ./resources/register.js examples/index.ts"
   },
   "dependencies": {
+    "@types/http-errors": "^1.8.0",
     "accepts": "^1.3.7",
     "content-type": "^1.0.4",
     "http-errors": "1.8.0",
@@ -62,7 +63,6 @@
     "@types/connect": "3.4.33",
     "@types/content-type": "1.1.3",
     "@types/express": "4.17.8",
-    "@types/http-errors": "1.8.0",
     "@types/mocha": "8.0.3",
     "@types/multer": "1.4.4",
     "@types/node": "14.6.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import type {
 } from 'graphql';
 import accepts from 'accepts';
 import httpError from 'http-errors';
+import type { HttpError } from 'http-errors';
 import {
   Source,
   parse,
@@ -100,7 +101,9 @@ export interface OptionsData {
    * fulfilling a GraphQL operation. If no function is provided, GraphQL's
    * default spec-compliant `formatError` function will be used.
    */
-  customFormatErrorFn?: (error: GraphQLError) => GraphQLFormattedError;
+  customFormatErrorFn?: (
+    error: GraphQLError | HttpError,
+  ) => GraphQLFormattedError;
 
   /**
    * An optional function which will be used to create a document instead of


### PR DESCRIPTION
`customFormatErrorFn` may be passed `HttpError` as well as `GraphQLError`. So the argument type of `customFormatErrorFn` should be `GraphQLError | HttpError`.

## Example

```typescript
import { graphqlHTTP } from "express-graphql";
import express from "express";
import { buildSchema, formatError, GraphQLError, GraphQLFormattedError } from "graphql";
import { HttpError } from "http-errors";

const app = express();

const schema = buildSchema(`
  type Query {
    hello: String
  }
`);

app.use(
  "/graphql",
  graphqlHTTP(() => {
    return {
      schema,
      customFormatErrorFn: (err: GraphQLError): GraphQLFormattedError => {
        (err as any).extensions = {
          name: err.name,
          isHttpError: err instanceof HttpError,
        };
        return formatError(err);
      },
    };
  })
);

app.listen(8000);
```

```
$ curl -s -X POST http://localhost:8000/graphql | jq
{
  "errors": [
    {
      "message": "Must provide query string.",
      "extensions": {
        "name": "BadRequestError",
        "isHttpError": true
      }
    }
  ]
}
```
