### PR TITLE
📚 Update docs with Helmet CSP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,9 +349,12 @@ getGraphQLParams(request).then((params) => {
 ```
 
 ### Integration with other express middlewares
+
 #### [Helmet](https://helmetjs.github.io/)
+
 When using Helmet the default CSP of helmet blocks graphiql's inline scripts support. To enable graphiql with helmet you need to update the contentSecurityPolicies with graphiql's needs.
 The code snippet below makes use of Helmet's default CSP and adds what graphiql needs.
+
 ```js
 app.use(
   helmet({

--- a/README.md
+++ b/README.md
@@ -348,6 +348,44 @@ getGraphQLParams(request).then((params) => {
 });
 ```
 
+### Integration with other express middlewares
+#### [Helmet](https://helmetjs.github.io/)
+When using Helmet the default CSP of helmet blocks graphiql's inline scripts support. To enable graphiql with helmet you need to update the contentSecurityPolicies with graphiql's needs.
+The code snippet below makes use of Helmet's default CSP and adds what graphiql needs.
+```js
+app.use(
+  helmet({
+    /**
+     * Default helmet policy + own customizations - graphiql support
+     * - https://helmetjs.github.io/
+     */
+    contentSecurityPolicy: helmet.contentSecurityPolicy({
+      directives: {
+        defaultSrc: [
+          "'self'",
+          /** @by-us - adds graphiql support over helmet's default CSP */
+          "'unsafe-inline'",
+        ],
+        baseUri: ["'self'"],
+        blockAllMixedContent: [],
+        fontSrc: ["'self'", 'https:', 'data:'],
+        frameAncestors: ["'self'"],
+        imgSrc: ["'self'", 'data:'],
+        objectSrc: ["'none'"],
+        scriptSrc: [
+          "'self'",
+          /** @by-us - adds graphiql support over helmet's default CSP */
+          "'unsafe-inline'",
+          /** @by-us - adds graphiql support over helmet's default CSP */
+          "'unsafe-eval'",
+        ],
+        upgradeInsecureRequests: [],
+      },
+    }),
+  }),
+);
+```
+
 ## Debugging Tips
 
 During development, it's useful to get more information from errors, such as

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ app.use(
      * Default helmet policy + own customizations - graphiql support
      * - https://helmetjs.github.io/
      */
-    contentSecurityPolicy: helmet.contentSecurityPolicy({
+    contentSecurityPolicy: {
       directives: {
         defaultSrc: [
           "'self'",
@@ -384,7 +384,7 @@ app.use(
         ],
         upgradeInsecureRequests: [],
       },
-    }),
+    },
   }),
 );
 ```

--- a/cspell.json
+++ b/cspell.json
@@ -14,7 +14,10 @@
     "tsconfig.json"
   ],
   "words": [
+    "eval",
     "graphiql",
+    "graphiql's",
+    "middlewares",
     "unfetch",
     "noindex",
     "codecov",


### PR DESCRIPTION
- Adds documentation explaining how to use Graphiql with the common express middleware Helmet.

Related issue: https://github.com/apollographql/apollo-server/issues/4648