### PR TITLE
fix(variables) allow to send empty string in variables

### DIFF
--- a/src/__tests__/http-test.ts
+++ b/src/__tests__/http-test.ts
@@ -190,6 +190,26 @@ function runTests(server: Server) {
       expect(response.text).to.equal('{"data":{"test":"Hello Dolly"}}');
     });
 
+    it('allows GET with empty variable', async () => {
+      const app = server();
+
+      app.get(
+        urlString(),
+        graphqlHTTP({
+          schema: TestSchema,
+        }),
+      );
+
+      const response = await app.request().get(
+        urlString({
+          query: '{test}',
+          variables: '',
+        }),
+      );
+
+      expect(response.text).to.equal('{"data":{"test":"Hello World"}}');
+    });
+
     it('allows GET with operation name', async () => {
       const app = server();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -479,7 +479,7 @@ export async function getGraphQLParams(
   let variables = (urlData.get('variables') ?? bodyData.variables) as {
     readonly [name: string]: unknown;
   } | null;
-  if (typeof variables === 'string') {
+  if (variables && typeof variables === 'string') {
     try {
       variables = JSON.parse(variables);
     } catch (error) {


### PR DESCRIPTION
Since this commit https://github.com/graphql/express-graphql/commit/ac9e1a9ca65e66f5c970028e7eae75a960192434
we use URLSearchParams which transform "?query=any&variables=" to variables="" 

````
const urlSearchParams = new URLSearchParams(' /graphql?query=any&variables=')
urlSearchParams.get('variables') // return ""
````

And now we have "Variables are invalid JSON." for empty variables
``````
if (typeof variables === 'string') {
    try {
      variables = JSON.parse(variables);
    } catch (error) {
      throw httpError(400, 'Variables are invalid JSON.');
    }
  } else if (typeof variables !== 'object') {
    variables = null;
  }
``````

Maybe we should allow empty string

