### PR TITLE
Allow custom graphql params extraction from request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1003,41 +1003,6 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
-    "babel-plugin-emotion": {
-      "version": "10.0.33",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
-      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/serialize": "^0.11.16",
-        "babel-plugin-macros": "^2.0.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^1.0.5",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7"
-      }
-    },
-    "babel-plugin-macros": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "cosmiconfig": "^6.0.0",
-        "resolve": "^1.12.0"
-      }
-    },
-    "babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-      "dev": true
-    },
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -3608,22 +3573,6 @@
       "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
       "dev": true
     },
-    "iterate-iterator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
-      "integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==",
-      "dev": true
-    },
-    "iterate-value": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
-      "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
-      "dev": true,
-      "requires": {
-        "es-get-iterator": "^1.0.2",
-        "iterate-iterator": "^1.0.1"
-      }
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5570,27 +5519,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
-    },
-    "styled-system": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-5.1.5.tgz",
-      "integrity": "sha512-7VoD0o2R3RKzOzPK0jYrVnS8iJdfkKsQJNiLRDjikOpQVqQHns/DXWaPZOH4tIKkhAT7I6wIsy9FWTWh2X3q+A==",
-      "dev": true,
-      "requires": {
-        "@styled-system/background": "^5.1.2",
-        "@styled-system/border": "^5.1.5",
-        "@styled-system/color": "^5.1.2",
-        "@styled-system/core": "^5.1.2",
-        "@styled-system/flexbox": "^5.1.2",
-        "@styled-system/grid": "^5.1.2",
-        "@styled-system/layout": "^5.1.2",
-        "@styled-system/position": "^5.1.2",
-        "@styled-system/shadow": "^5.1.2",
-        "@styled-system/space": "^5.1.2",
-        "@styled-system/typography": "^5.1.2",
-        "@styled-system/variant": "^5.1.5",
-        "object-assign": "^4.1.1"
-      }
     },
     "subscriptions-transport-ws": {
       "version": "0.5.4",

--- a/src/__tests__/http-test.ts
+++ b/src/__tests__/http-test.ts
@@ -1029,6 +1029,36 @@ function runTests(server: Server) {
     });
   });
 
+  it('allow custom graphql params extraction from request', async () => {
+    const app = server();
+
+    app.get(
+      urlString(),
+      graphqlHTTP(
+        {
+          schema: TestSchema,
+        },
+        (request) => {
+          const searchParams = new URLSearchParams(request.url.split('?')[1]);
+          return {
+            query: searchParams.get('graphqlQuery'),
+            variables: null,
+            operationName: null,
+            raw: false,
+          };
+        },
+      ),
+    );
+
+    const response = await app.request().get(
+      urlString({
+        graphqlQuery: '{test}',
+      }),
+    );
+
+    expect(response.text).to.equal('{"data":{"test":"Hello World"}}');
+  });
+
   describe('Pretty printing', () => {
     it('supports pretty printing', async () => {
       const app = server();

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,7 +195,16 @@ type Middleware = (request: Request, response: Response) => Promise<void>;
  * Middleware for express; takes an options object or function as input to
  * configure behavior, and returns an express middleware.
  */
-export function graphqlHTTP(options: Options): Middleware {
+export function graphqlHTTP(
+  options: Options,
+  /**
+   * An optional function which will get params from request instead of
+   * default getGraphQLParams
+   */
+  customGraphQLParamsFn?: (
+    request: Request,
+  ) => GraphQLParams | Promise<GraphQLParams>,
+): Middleware {
   devAssert(options != null, 'GraphQL middleware requires options.');
 
   return async function graphqlMiddleware(
@@ -210,11 +219,12 @@ export function graphqlHTTP(options: Options): Middleware {
     let pretty = false;
     let result: ExecutionResult;
     let optionsData: OptionsData | undefined;
+    const graphQLParamsFn = customGraphQLParamsFn ?? getGraphQLParams;
 
     try {
       // Parse the Request to get GraphQL request parameters.
       try {
-        params = await getGraphQLParams(request);
+        params = await graphQLParamsFn(request);
       } catch (error: unknown) {
         // When we failed to parse the GraphQL parameters, we still need to get
         // the options object, so make an options call to resolve just that.


### PR DESCRIPTION
In my app I'm trying to move away from express. I implemented own
body parser to not pollute `request` object. Though in this case
express-graphql is trying to parse body by itself which leads to hanging
server because there are no more events on request.

In this diff I added a way to custom extracting params from request.
It would look better in options though options getter depends on parsed
options.