### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,14 +373,14 @@ application any more secure. Nevertheless, disabling introspection is possible b
 package.
 
 ```js
-import { specifiedRules, NoSchemaIntrospectionCustomRule } from 'graphql';
+import { NoSchemaIntrospectionCustomRule } from 'graphql';
 
 app.use(
   '/graphql',
   graphqlHTTP((request) => {
     return {
       schema: MyGraphQLSchema,
-      validationRules: [...specifiedRules, NoSchemaIntrospectionCustomRule],
+      validationRules: [NoSchemaIntrospectionCustomRule],
     };
   }),
 );


### PR DESCRIPTION
Remove `specifiedRules` from the README example for disabling introspection, since in the source code at `express-graphql/src/index.ts: 303`, `specifiedRules` is already imported and used