### PR TITLE
Revert "Allow custom handling of runtime query errors"

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,6 @@ The `graphqlHTTP` function accepts the following options:
 - **`formatError`**: is deprecated and replaced by `customFormatErrorFn`. It will be
   removed in version 1.0.0.
 
-- **`handleRuntimeQueryErrorFn`**: An optional function which can be used to change the status code
-  or headers of the response in case of a runtime query error. By default, the status code is set to
-  `500`.
-
 In addition to an object defining each option, options can also be provided as
 a function (or async function) which returns this options object. This function
 is provided the arguments `(request, response, graphQLParams)` and is called

--- a/src/__tests__/usage-test.ts
+++ b/src/__tests__/usage-test.ts
@@ -2,12 +2,7 @@ import express from 'express';
 import request from 'supertest';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import {
-  GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLSchema,
-  GraphQLString,
-} from 'graphql';
+import { GraphQLSchema } from 'graphql';
 
 import { graphqlHTTP } from '../index';
 
@@ -99,40 +94,6 @@ describe('Useful errors when incorrectly used', () => {
         { message: 'GraphQL middleware options must contain a schema.' },
       ],
     });
-  });
-
-  it('uses the custom runtime query error handling function', async () => {
-    const schema = new GraphQLSchema({
-      query: new GraphQLObjectType({
-        name: 'QueryRoot',
-        fields: {
-          test: {
-            type: new GraphQLNonNull(GraphQLString),
-            resolve() {
-              throw new Error('Throws!');
-            },
-          },
-        },
-      }),
-    });
-
-    const app = express();
-
-    app.use(
-      '/graphql',
-      graphqlHTTP({
-        handleRuntimeQueryErrorFn(_, response) {
-          response.setHeader('customRuntimeQueryError', "I'm a teapot");
-          response.statusCode = 418;
-        },
-        schema,
-      }),
-    );
-
-    const response = await request(app).get('/graphql?query={test}');
-
-    expect(response.status).to.equal(418);
-    expect(response.get('customRuntimeQueryError')).to.equal("I'm a teapot");
   });
 
   it('validates schema before executing request', async () => {


### PR DESCRIPTION
Reverts graphql/express-graphql#696

we have to be following the transport spec error codes:

https://github.com/graphql/graphql-over-http/blob/master/spec/GraphQLOverHTTP.md#status-codes