### PR TITLE
fix: failing tests on Node 12

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,4 +1,3 @@
-throw-deprecation: true
 check-leaks: true
 require:
   - './resources/register.js'


### PR DESCRIPTION
Closes #756 

The issue of tests failing on Node 12 was caused by the `throw-deprecation: true` option specified in `.mocharc.yml`.


CC: @acao @junminstorage 