### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -328,6 +328,14 @@
         "graphql-ws": "^4.1.0",
         "meros": "^1.1.2",
         "subscriptions-transport-ws": "^0.9.18"
+      },
+      "dependencies": {
+        "graphql-ws": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-4.7.0.tgz",
+          "integrity": "sha512-Md8SsmC9ZlsogFPd3Ot8HbIAAqsHh8Xoq7j4AmcIat1Bh6k91tjVyQvA0Au1/BolXSYq+RDvib6rATU2Hcf1Xw==",
+          "dev": true
+        }
       }
     },
     "@istanbuljs/load-nyc-config": {
@@ -494,6 +502,30 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.7.tgz",
+      "integrity": "sha512-aBvUmXLQbayM4w3A8TrjwrXs4DZ8iduJnuJLLRGdkWlyakCf1q6uHZJBzXoRA/huAEknG5tcUyQxN3A+In5euQ==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.7.tgz",
+      "integrity": "sha512-dgasobK/Y0wVMswcipr3k0HpevxFJLijN03A8mYfEPvWvOs14v0ZlYTR4kIgMx8g4+fTyTFv8/jLCIfRqLDJ4A==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.0.tgz",
+      "integrity": "sha512-RKkL8eTdPv6t5EHgFKIVQgsDapugbuOptNd9OOunN/HAkzmmTnZELx1kNCK0rSdUYGmiFMM3rRQMAWiyp023LQ==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
+      "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
       "dev": true
     },
     "@types/accepts": {
@@ -1520,6 +1552,12 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2236,7 +2274,8 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
       "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -3098,6 +3137,7 @@
       "resolved": "https://registry.npmjs.org/graphiql-subscriptions-fetcher/-/graphiql-subscriptions-fetcher-0.0.2.tgz",
       "integrity": "sha1-Tmy8sUdMLXaxE1XVdndC0eQpEWI=",
       "dev": true,
+      "optional": true,
       "requires": {
         "graphql": "^0.9.1",
         "subscriptions-transport-ws": "0.5.4"
@@ -3108,6 +3148,7 @@
           "resolved": "https://registry.npmjs.org/@types/ws/-/ws-0.0.38.tgz",
           "integrity": "sha1-QhBv/0tCLKlWc04p8Nc6bYkxlNM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "@types/node": "*"
           }
@@ -3116,13 +3157,15 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
           "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "graphql": {
           "version": "0.9.6",
           "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.9.6.tgz",
           "integrity": "sha1-UUQh6dIlwp38j9MFRZq65YgV7yw=",
           "dev": true,
+          "optional": true,
           "requires": {
             "iterall": "^1.0.0"
           }
@@ -3132,6 +3175,7 @@
           "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.5.4.tgz",
           "integrity": "sha1-EJHlXnO/8NaRqGVwrCuX/2+zXPw=",
           "dev": true,
+          "optional": true,
           "requires": {
             "@types/ws": "0.0.38",
             "backo2": "^1.0.2",
@@ -3148,6 +3192,7 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
           "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
           "dev": true,
+          "optional": true,
           "requires": {
             "options": ">=0.0.5",
             "ultron": "1.0.x"
@@ -3156,9 +3201,9 @@
       }
     },
     "graphql": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
-      "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
       "dev": true
     },
     "graphql-language-service": {
@@ -3213,6 +3258,7 @@
       "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-0.3.1.tgz",
       "integrity": "sha1-DO3C1QdCDPJs9BQICwefBUAvAwM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "es6-promise": "^3.2.1"
       }
@@ -3221,13 +3267,15 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-1.3.2.tgz",
       "integrity": "sha1-ers6j9nzQV0HFjMU7SNwYceFt1k=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "graphql-ws": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-4.1.2.tgz",
-      "integrity": "sha512-c/iOE4kGW6J5h9hmHWaYvgsjAQacioae3ZXvq3JDuVw8uXo3Tbmky71Fzn0+emSKRaRNL1jQuzYtRqFKge2PIw==",
-      "dev": true
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-4.1.3.tgz",
+      "integrity": "sha512-G32UQ/Fw5b8Z1kMwO4lv9vsdS1ndJXm+OJfC7CM+WxElAXe8TGA7GhMjd0hQ2dymXyeIt8T3vK/6dYLlUmJ8zA==",
+      "dev": true,
+      "optional": true
     },
     "growl": {
       "version": "1.10.5",
@@ -3837,13 +3885,15 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
       "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "log-symbols": {
       "version": "4.0.0",
@@ -4529,7 +4579,8 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "p-limit": {
       "version": "1.3.0",
@@ -5624,6 +5675,17 @@
         "iterall": "^1.2.1",
         "symbol-observable": "^1.0.4",
         "ws": "^5.2.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
       }
     },
     "superagent": {
@@ -5766,12 +5828,17 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "ts-node": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.0.0.tgz",
-      "integrity": "sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.0.0.tgz",
+      "integrity": "sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==",
       "dev": true,
       "requires": {
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.1",
         "arg": "^4.1.0",
+        "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.17",
@@ -5858,9 +5925,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
-      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
       "dev": true
     },
     "uc.micro": {
@@ -5873,7 +5940,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "unfetch": {
       "version": "4.2.0",
@@ -6135,13 +6203,10 @@
       }
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-      "dev": true,
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -89,8 +89,8 @@
     "express": "4.17.1",
     "graphiql": "^1.4.1",
     "graphiql-subscriptions-fetcher": "0.0.2",
-    "graphql": "15.4.0",
-    "graphql-ws": "4.1.2",
+    "graphql": "15.5.0",
+    "graphql-ws": "4.1.3",
     "mocha": "8.2.1",
     "multer": "1.4.2",
     "nyc": "15.1.0",
@@ -102,12 +102,16 @@
     "sinon": "9.2.1",
     "subscriptions-transport-ws": "0.9.18",
     "supertest": "6.0.1",
-    "ts-node": "9.0.0",
-    "typescript": "4.1.2",
+    "ts-node": "10.0.0",
+    "typescript": "4.3.2",
     "unfetch": "4.2.0",
-    "ws": "5.2.2"
+    "ws": "7.4.6"
   },
   "peerDependencies": {
-    "graphql": "^14.7.0 || ^15.3.0"
+    "graphql": "^14.7.0 || ^15.5.0"
+  },
+  "optionalDependencies": {
+    "graphql-ws": "4.1.3",
+    "graphiql-subscriptions-fetcher": "0.0.2"
   }
 }


### PR DESCRIPTION
must lock to `graphql-ws@4.1.3` for now
load static modules script is not compatible with any later version.
I get `ERR_PACKAGE_PATH_NOT_EXPORTED`?