### PR TITLE
Update Node and TypeScript versions in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version_to_setup: [10, 12, 14, 15]
+        node_version_to_setup: [10, 12, 14, 16]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/integrationTests/node/package.json
+++ b/integrationTests/node/package.json
@@ -9,6 +9,6 @@
     "node-10": "npm:node@10.x.x",
     "node-12": "npm:node@12.x.x",
     "node-14": "npm:node@14.x.x",
-    "node-15": "npm:node@15.x.x"
+    "node-16": "npm:node@16.x.x"
   }
 }

--- a/integrationTests/ts/package.json
+++ b/integrationTests/ts/package.json
@@ -14,6 +14,8 @@
     "typescript-3.8": "npm:typescript@3.8.x",
     "typescript-3.9": "npm:typescript@3.9.x",
     "typescript-4.0": "npm:typescript@4.0.x",
-    "typescript-4.1": "npm:typescript@4.1.x"
+    "typescript-4.1": "npm:typescript@4.1.x",
+    "typescript-4.2": "npm:typescript@4.2.x",
+    "typescript-4.3": "npm:typescript@4.3.x"
   }
 }


### PR DESCRIPTION
- Replace Node 15 in tests with Node 16.
- Run integration tests also on TypeScript 4.2 and 4.3.