### PR TITLE
fix: Allow empty operation names for single queries

### DIFF
--- a/src/__tests__/http-test.ts
+++ b/src/__tests__/http-test.ts
@@ -813,6 +813,35 @@ function runTests(server: Server) {
       });
     });
 
+    it('allows POST with empty operation name', async () => {
+      const app = server();
+
+      app.post(
+        urlString(),
+        graphqlHTTP(() => ({
+          schema: TestSchema,
+        })),
+      );
+
+      const response = await app.request().post(urlString()).send({
+        query: `
+            query { test(who: "World"), ...shared }
+            fragment shared on QueryRoot {
+              shared: test(who: "Everyone")
+            }
+          `,
+        operationName: '',
+      });
+
+      expect(JSON.parse(response.text)).to.deep.equal({
+        data: {
+          test: 'Hello World',
+          shared: 'Hello Everyone',
+        },
+      });
+    });
+
+
     it('allows POST with GET operation name', async () => {
       const app = server();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -501,7 +501,7 @@ export async function getGraphQLParams(
   // Name of GraphQL operation to execute.
   let operationName =
     urlData.get('operationName') ?? (bodyData.operationName as string | null);
-  if (typeof operationName !== 'string') {
+  if (typeof operationName !== 'string' || operationName.length === 0) {
     operationName = null;
   }
 


### PR DESCRIPTION
Fixes issue #767 