### PR TITLE
Allow custom handling of runtime query errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ The `graphqlHTTP` function accepts the following options:
 - **`formatError`**: is deprecated and replaced by `customFormatErrorFn`. It will be
   removed in version 1.0.0.
 
+- **`handleRuntimeQueryErrorFn`**: An optional function which can be used to change the headers or status code of the response in case of a runtime query error. By default, the status code is set to `500`.
+  To ensure compatibility, make sure to take note of [the GraphQL spec regarding status codes](https://github.com/graphql/graphql-over-http/blob/master/spec/GraphQLOverHTTP.md#status-codes).
+
 In addition to an object defining each option, options can also be provided as
 a function (or async function) which returns this options object. This function
 is provided the arguments `(request, response, graphQLParams)` and is called

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,15 @@ export interface OptionsData {
   formatError?: (error: GraphQLError) => GraphQLFormattedError;
 
   /**
+   * Use this to modify the response when a runtime query error occurs. By
+   * default the statusCode will be set to 500.
+   */
+  handleRuntimeQueryErrorFn?: (
+    result: ExecutionResult,
+    response: Response,
+  ) => void;
+
+  /**
    * An optional function for adding additional metadata to the GraphQL response
    * as a key-value object. The result will be added to "extensions" field in
    * the resulting JSON. This is often a useful place to add development time
@@ -197,6 +206,7 @@ export function graphqlHTTP(options: Options): Middleware {
     let formatErrorFn = formatError;
     let pretty = false;
     let result: ExecutionResult;
+    let optionsData: OptionsData | undefined;
 
     try {
       // Parse the Request to get GraphQL request parameters.
@@ -205,7 +215,7 @@ export function graphqlHTTP(options: Options): Middleware {
       } catch (error: unknown) {
         // When we failed to parse the GraphQL parameters, we still need to get
         // the options object, so make an options call to resolve just that.
-        const optionsData = await resolveOptions();
+        optionsData = await resolveOptions();
         pretty = optionsData.pretty ?? false;
         formatErrorFn =
           optionsData.customFormatErrorFn ??
@@ -215,7 +225,7 @@ export function graphqlHTTP(options: Options): Middleware {
       }
 
       // Then, resolve the Options to get OptionsData.
-      const optionsData = await resolveOptions(params);
+      optionsData = await resolveOptions(params);
 
       // Collect information from the options data object.
       const schema = optionsData.schema;
@@ -384,13 +394,22 @@ export function graphqlHTTP(options: Options): Middleware {
       }
     }
 
-    // If no data was included in the result, that indicates a runtime query
-    // error, indicate as such with a generic status code.
-    // Note: Information about the error itself will still be contained in
-    // the resulting JSON payload.
-    // https://graphql.github.io/graphql-spec/#sec-Data
-    if (response.statusCode === 200 && result.data == null) {
-      response.statusCode = 500;
+    if (result.errors != null || result.data == null) {
+      const handleRuntimeQueryErrorFn =
+        optionsData?.handleRuntimeQueryErrorFn ??
+        ((_result, _response) => {
+          // If no data was included in the result, that indicates a runtime query
+          // error, indicate as such with a generic status code.
+          // Note: Information about the error itself will still be contained in
+          // the resulting JSON payload.
+          // https://graphql.github.io/graphql-spec/#sec-Data
+
+          if (_response.statusCode === 200 && _result.data == null) {
+            _response.statusCode = 500;
+          }
+        });
+
+      handleRuntimeQueryErrorFn(result, response);
     }
 
     // Format any encountered errors.


### PR DESCRIPTION
Closes #427. 
Closes #808. 

**Why**  
When runtime errors occur, tracing and logging is paramount to discern between incorrect user input or a faulty backend/frontend. To this end, tracing info can be added to response headers in order for proxies/frontends to log this error and update metrics.

Without this PR, achieving this goal is only possible using dirty solutions such as [hijackresponse](https://www.npmjs.com/package/hijackresponse) since `express-graphql` finalizes the response which prevents later middleware from enhancing it. 